### PR TITLE
refactor(express): renames *InterceptorParser to *Parser

### DIFF
--- a/integration/express/src/app.module.ts
+++ b/integration/express/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { OgmaModule } from '@ogma/nestjs-module';
-import { ExpressInterceptorParser } from '@ogma/platform-express';
+import { ExpressParser } from '@ogma/platform-express';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
@@ -8,7 +8,7 @@ import { AppService } from './app.service';
   imports: [
     OgmaModule.forRoot({
       interceptor: {
-        http: ExpressInterceptorParser,
+        http: ExpressParser,
       },
     }),
   ],

--- a/integration/fastify/src/app.module.ts
+++ b/integration/fastify/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { OgmaModule } from '@ogma/nestjs-module';
-import { FastifyInterceptorParser } from '@ogma/platform-fastify';
+import { FastifyParser } from '@ogma/platform-fastify';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 
@@ -8,7 +8,7 @@ import { AppService } from './app.service';
   imports: [
     OgmaModule.forRoot({
       interceptor: {
-        http: FastifyInterceptorParser,
+        http: FastifyParser,
       },
     }),
   ],

--- a/integration/socket.io/src/app.module.ts
+++ b/integration/socket.io/src/app.module.ts
@@ -1,6 +1,6 @@
 import { Module } from '@nestjs/common';
 import { OgmaModule } from '@ogma/nestjs-module';
-import { SocketioInterceptorParser } from '@ogma/platform-socket.io';
+import { SocketioParser } from '@ogma/platform-socket.io';
 import { AppGateway } from './app.gateway';
 import { AppService } from './app.service';
 
@@ -8,7 +8,7 @@ import { AppService } from './app.service';
   imports: [
     OgmaModule.forRoot({
       interceptor: {
-        ws: SocketioInterceptorParser,
+        ws: SocketioParser,
       },
     }),
   ],

--- a/packages/platform-express/src/express-interceptor.service.ts
+++ b/packages/platform-express/src/express-interceptor.service.ts
@@ -4,7 +4,7 @@ import { AbstractInterceptorService } from '@ogma/nestjs-module';
 import { Request, Response } from 'express';
 
 @Injectable()
-export class ExpressInterceptorParser extends AbstractInterceptorService {
+export class ExpressParser extends AbstractInterceptorService {
   getCallerIp(context: ExecutionContext): string[] | string {
     const req = this.getRequest(context);
     return req.ips.length ? req.ips : req.ip;

--- a/packages/platform-fastify/src/fastify-interceptor.service.ts
+++ b/packages/platform-fastify/src/fastify-interceptor.service.ts
@@ -5,7 +5,7 @@ import { FastifyReply, FastifyRequest } from 'fastify';
 import { ServerResponse } from 'http';
 
 @Injectable()
-export class FastifyInterceptorParser extends AbstractInterceptorService {
+export class FastifyParser extends AbstractInterceptorService {
   getCallerIp(context: ExecutionContext): string[] | string {
     const req = this.getRequest(context);
     return req.ips && req.ips.length ? req.ips : req.ip;

--- a/packages/platform-socket.io/src/socket-io-interceptor.service.ts
+++ b/packages/platform-socket.io/src/socket-io-interceptor.service.ts
@@ -4,7 +4,7 @@ import { AbstractInterceptorService } from '@ogma/nestjs-module';
 import { Socket } from 'socket.io';
 
 @Injectable()
-export class SocketioInterceptorParser extends AbstractInterceptorService {
+export class SocketioParser extends AbstractInterceptorService {
   getCallPoint(context: ExecutionContext): string {
     return this.reflector.get(MESSAGE_METADATA, context.getHandler());
   }


### PR DESCRIPTION
For the ease of use of the OgmaInterceptor, the parsing services have had a name change from
*InterpceotrParser to simply *Parser, to both be more concise and easier to understand.