### PR TITLE
feat(ws): implements parser for websocket

### DIFF
--- a/integration/src/ws/ws.filter.ts
+++ b/integration/src/ws/ws.filter.ts
@@ -1,10 +1,15 @@
 import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
 import { BaseWsExceptionFilter } from '@nestjs/websockets';
+import WebSocket = require('ws');
 
 @Catch()
 export class ExceptionFilter extends BaseWsExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const client = host.switchToWs().getClient();
-    client.emit('exception', exception.message);
+    if (client instanceof WebSocket) {
+      return client.send('exception');
+    } else {
+      return client.emit('exception', exception.message);
+    }
   }
 }

--- a/integration/test/gql.spec.ts
+++ b/integration/test/gql.spec.ts
@@ -72,9 +72,9 @@ describe.each`
 
       describe.each`
         type          | name             | status
-        ${'query'}    | ${'getQuery'}    | ${200}
-        ${'query'}    | ${'getError'}    | ${400}
-        ${'mutation'} | ${'getMutation'} | ${200}
+        ${'query'}    | ${'getQuery'}    | ${color.green(200)}
+        ${'query'}    | ${'getError'}    | ${color.yellow(400)}
+        ${'mutation'} | ${'getMutation'} | ${color.green(200)}
       `(
         '$type $name',
         ({
@@ -84,7 +84,7 @@ describe.each`
         }: {
           type: string;
           name: string;
-          status: number;
+          status: string;
         }) => {
           it('should log the call', async () => {
             await gqlPromise(baseUrl, {
@@ -95,7 +95,7 @@ describe.each`
               type,
               '/graphql',
               'HTTP/1.1',
-              status === 200 ? color.green(status) : color.yellow(status),
+              status,
             );
           });
         },

--- a/integration/test/utils/index.ts
+++ b/integration/test/utils/index.ts
@@ -10,6 +10,9 @@ export * from './gql-promise';
 export * from './http-promise';
 export * from './ws-promise';
 export const hello = JSON.stringify({ hello: 'world' });
-export const serviceOptionsFactory = (app: string): OgmaServiceOptions => {
-  return { application: app, stream };
+export const serviceOptionsFactory = (
+  app: string,
+  json = false,
+): OgmaServiceOptions => {
+  return { application: app, stream, json };
 };

--- a/integration/test/utils/matcher.ts
+++ b/integration/test/utils/matcher.ts
@@ -2,6 +2,10 @@
 
 import { color } from '@ogma/logger';
 import { isIP } from 'net';
+import { LogObject } from '@ogma/nestjs-module/lib/interceptor/interfaces/log.interface';
+
+const timeRegex = /\d+ms/;
+const sizeRegex = /\d+/;
 
 /* eslint-disable @typescript-eslint/no-namespace */
 declare global {
@@ -22,62 +26,113 @@ const expectMessage = (field: string, expected: string, actual: string) =>
     actual,
   )}.\n`;
 
+const returnMessage = (pass: boolean, message: string) => ({
+  pass,
+  message: () =>
+    pass
+      ? 'This matcher is not made to work with negation. Please do not use it'
+      : message,
+});
+
+const doTest = (
+  recIp: string,
+  method: string,
+  recMethod: string,
+  endpoint: string,
+  recEndpoint: string,
+  protocol: string,
+  recProto: string,
+  status: string,
+  recStatus: string,
+  recTime: string,
+  recSize: string,
+): { pass: boolean; message: () => string } => {
+  let pass = true;
+  let message = '';
+  if (!isIP(recIp) && !isIP(recIp.split(':')[0])) {
+    pass = false;
+    message += expectMessage('Caller Ip', 'an IPv4 or IPv6', recIp);
+  }
+  if (recMethod !== method) {
+    pass = false;
+    message += expectMessage('method', method, recMethod);
+  }
+  if (recEndpoint !== endpoint) {
+    pass = false;
+    message += expectMessage('endpoint', endpoint, recEndpoint);
+  }
+  if (recProto !== protocol) {
+    pass = false;
+    message += expectMessage('protocol', protocol, recProto);
+  }
+  if (recStatus !== status) {
+    pass = false;
+    message += expectMessage('status', status, recStatus);
+  }
+  if (!timeRegex.test(recTime)) {
+    pass = false;
+    message += expectMessage('time', 'a time in milliseconds', recTime);
+  }
+  if (!sizeRegex.test(recSize)) {
+    pass = false;
+    message += expectMessage('size', 'a content-size in bytes', recSize);
+  }
+  return returnMessage(pass, message);
+};
+
 expect.extend({
   toBeALogObject(
-    received: string,
+    received: string | LogObject,
     method: string,
     endpoint: string,
     protocol: string,
     status: string,
   ) {
-    let pass = true;
-    let message = '';
-    const [
+    let recIp: string,
+      recMethod: string,
+      recEndpoint: string,
+      recProto: string,
+      recStatus: string,
+      recTime: string,
+      recSize: string;
+    if (typeof received === 'string') {
+      [
+        recIp,
+        ,
+        recMethod,
+        recEndpoint,
+        recProto,
+        recStatus,
+        recTime,
+        ,
+        recSize,
+      ] = received.split(' ');
+    } else {
+      ({
+        callerAddress: recIp as any,
+        protocol: recProto,
+        callPoint: recEndpoint,
+        responseTime: recTime as any,
+        status: recStatus,
+        method: recMethod,
+        contentLength: recSize as any,
+      } = received);
+      recTime = `${recTime.toString()}ms`;
+      recSize = recSize.toString();
+    }
+    return doTest(
       recIp,
-      ,
+      method,
       recMethod,
+      endpoint,
       recEndpoint,
+      protocol,
       recProto,
+      status,
       recStatus,
       recTime,
-      ,
       recSize,
-    ] = received.split(' ');
-    if (!isIP(recIp) && !isIP(recIp.split(':')[0])) {
-      pass = false;
-      message += expectMessage('Caller Ip', 'an IPv4 or IPv6', recIp);
-    }
-    if (recMethod !== method) {
-      pass = false;
-      message += expectMessage('method', method, recMethod);
-    }
-    if (recEndpoint !== endpoint) {
-      pass = false;
-      message += expectMessage('endpoint', endpoint, recEndpoint);
-    }
-    if (recProto !== protocol) {
-      pass = false;
-      message += expectMessage('protocol', protocol, recProto);
-    }
-    if (recStatus !== status) {
-      pass = false;
-      message += expectMessage('status', status, recStatus);
-    }
-    if (!/\d+ms/.test(recTime)) {
-      pass = false;
-      message += expectMessage('time', 'a time in milliseconds', recTime);
-    }
-    if (!/\d+/.test(recSize)) {
-      pass = false;
-      message += expectMessage('size', 'a content-size in bytes', recSize);
-    }
-    return {
-      pass,
-      message: () =>
-        pass
-          ? 'This matcher is not made to work with negation. Please do not use it'
-          : message,
-    };
+    );
   },
 });
 

--- a/integration/test/utils/ws-promise.ts
+++ b/integration/test/utils/ws-promise.ts
@@ -1,26 +1,53 @@
 import * as WebSocket from 'ws';
 
+export const createConnection = (
+  client: (url: string) => SocketIOClient.Socket | WebSocket,
+  url: string,
+): Promise<SocketIOClient.Socket | WebSocket> =>
+  new Promise((resolve, reject) => {
+    const socket = client(url);
+    if (Object.getOwnPropertyDescriptor(socket, 'io')) {
+      resolve(socket);
+    }
+    socket.on('open', () => {
+      resolve(socket);
+    });
+    socket.on('error', (err) => {
+      reject(err);
+    });
+  });
+
 export const wsPromise = (
   ws: WebSocket | SocketIOClient.Socket,
   message: string,
+  sendMethod: 'send' | 'emit',
 ): Promise<any> =>
   new Promise((resolve, reject) => {
-    ws.emit(message, '', (data) => resolve(data));
+    ws[sendMethod](message, {}, (data: any) => {
+      if (data) {
+        resolve(data);
+      }
+    });
+    ws.on('message', (data) => {
+      resolve(data);
+      return false;
+    });
     ws.on('error', (err) => {
       console.error(err);
       reject(err);
     });
-    ws.on('message', (data) => {
-      console.log(`Got data ${data}`);
-      resolve(data);
-    });
-    ws.on('ping', () => {
-      resolve('ping');
-    });
-    ws.on('pong', () => {
-      resolve('pong');
-    });
     ws.on('exception' as any, (...args) => {
       resolve(args);
     });
+    ws.on('unexpected-response', () => {
+      reject('Unexpected-response');
+    });
+  });
+export const wsClose = (ws: WebSocket | SocketIOClient.Socket): Promise<void> =>
+  new Promise((resolve, reject) => {
+    ws.close();
+    ws.on('close', () => {
+      resolve();
+    });
+    ws.on('error', (err) => reject(err));
   });

--- a/packages/platform-socket.io/README.md
+++ b/packages/platform-socket.io/README.md
@@ -20,3 +20,7 @@ This plugin is to be used in the `OgmaInterceptorOptions` portion of the `OgmaMo
 )
 export class AppModule {}
 ```
+
+### Note
+
+As the Gateway/Websocket context runs in parallel with the HTTP Context, and as the application configuration is not shared between the two, to bind the `OgmaInterceptor` to the GateWay, you **must** use `@UseInterceptor(OgmaInterceptor)` **and** have `OgmaModule.forFeature()` in the `imports` array of the same module.

--- a/packages/platform-ws/README.md
+++ b/packages/platform-ws/README.md
@@ -1,11 +1,26 @@
 # `@ogma/platform-ws`
 
-> TODO: description
+The `WsParser` parser for the `OgmaInterceptor`. This plugin class parses TCP request and response object to be able to successfully log the data about the request. For more information, check out [the @ogma/nestjs-module](../nestjs-module/README.md) documentation.
+
+## Installation
+
+Nothing special, standard `npm i @ogma/platform-ws` or `yarn add @ogma/platform-ws`
 
 ## Usage
 
-```
-const platformWs = require('@ogma/platform-ws');
+This plugin is to be used in the `OgmaInterceptorOptions` portion of the `OgmaModule` during `forRoot` or `forRootAsync` registration. It can be used like so:
 
-// TODO: DEMONSTRATE API
+```ts
+@Module(
+  OgmaModule.forRoot({
+    interceptor: {
+      ws: WsParser
+    }
+  })
+)
+export class AppModule {}
 ```
+
+### Note
+
+As the Gateway/Websocket context runs in parallel with the HTTP Context, and as the application configuration is not shared between the two, to bind the `OgmaInterceptor` to the GateWay, you **must** use `@UseInterceptor(OgmaInterceptor)` **and** have `OgmaModule.forFeature()` in the `imports` array of the same module.

--- a/packages/platform-ws/package.json
+++ b/packages/platform-ws/package.json
@@ -26,7 +26,11 @@
     "url": "git+https://github.com/jmcdo29/ogma.git"
   },
   "scripts": {
-    "test": "echo \"No tests to run\""
+    "prebuild": "rimraf lib",
+    "build": "tsc -p tsconfig.build.json",
+    "postbuild": "mv ./lib/src/* ./lib && rmdir lib/src",
+    "test": "jest",
+    "test:cov": "jest --coverage"
   },
   "bugs": {
     "url": "https://github.com/jmcdo29/ogma/issues"

--- a/packages/platform-ws/src/index.ts
+++ b/packages/platform-ws/src/index.ts
@@ -1,0 +1,1 @@
+export * from './ws-interceptor.service';

--- a/packages/platform-ws/src/ws-interceptor.service.ts
+++ b/packages/platform-ws/src/ws-interceptor.service.ts
@@ -1,0 +1,35 @@
+import { ExecutionContext, HttpException, Injectable } from '@nestjs/common';
+import { MESSAGE_METADATA } from '@nestjs/websockets/constants';
+import { AbstractInterceptorService } from '@ogma/nestjs-module';
+import WebSocket = require('ws');
+
+@Injectable()
+export class WsParser extends AbstractInterceptorService {
+  getCallPoint(context: ExecutionContext): string {
+    return this.reflector.get<string>(MESSAGE_METADATA, context.getHandler());
+  }
+
+  getCallerIp(context: ExecutionContext): string {
+    return (this.getClient(context) as any)._socket.remoteAddress;
+  }
+
+  getProtocol(): string {
+    return 'WS';
+  }
+
+  getMethod(): string {
+    return 'websocket';
+  }
+
+  getStatus(
+    context: ExecutionContext,
+    inColor: boolean,
+    error?: HttpException | Error,
+  ): string {
+    const status = error ? 500 : 200;
+    return inColor ? this.wrapInColor(status) : status.toString();
+  }
+  private getClient(context: ExecutionContext): WebSocket {
+    return context.switchToWs().getClient<WebSocket>();
+  }
+}

--- a/packages/platform-ws/tests/ws-interceptor.service.spec.ts
+++ b/packages/platform-ws/tests/ws-interceptor.service.spec.ts
@@ -1,0 +1,84 @@
+import { createMock } from '@golevelup/ts-jest';
+import { BadRequestException, ExecutionContext } from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Test } from '@nestjs/testing';
+import { MESSAGE_METADATA } from '@nestjs/websockets/constants';
+import { color } from '@ogma/logger';
+import { WsParser } from '@ogma/platform-ws';
+
+describe('WsParser', () => {
+  let parser: WsParser;
+  let reflector: Reflector;
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      providers: [
+        WsParser,
+        {
+          provide: Reflector,
+          useValue: {
+            get: jest.fn(() => 'message'),
+          },
+        },
+      ],
+    }).compile();
+    parser = modRef.get(WsParser);
+    reflector = modRef.get(Reflector);
+  });
+
+  describe('getCallPoint', () => {
+    it('should return "message"', () => {
+      const funcMock = () => 'string';
+      const ctxMock = createMock<ExecutionContext>({
+        getHandler: () => funcMock(),
+      });
+      expect(parser.getCallPoint(ctxMock)).toBe('message');
+      expect(reflector.get).toBeCalledWith(MESSAGE_METADATA, funcMock());
+    });
+  });
+  describe('getCallerIp', () => {
+    it('should return the IP', () => {
+      const ctxMock = createMock<ExecutionContext>({
+        switchToWs: () => ({
+          getClient: () => ({
+            _socket: {
+              remoteAddress: '127.0.0.1',
+            },
+          }),
+        }),
+      });
+      expect(parser.getCallerIp(ctxMock)).toBe('127.0.0.1');
+    });
+  });
+  describe('getProtocol', () => {
+    it('should return "WS"', () => {
+      expect(parser.getProtocol()).toBe('WS');
+    });
+  });
+  describe('getMethod', () => {
+    it('should return "websocket"', () => {
+      expect(parser.getMethod()).toBe('websocket');
+    });
+  });
+  describe('getStatus', () => {
+    it('should return a 200', () => {
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
+        '200',
+      );
+    });
+    it('should return a 500', () => {
+      expect(
+        parser.getStatus(
+          createMock<ExecutionContext>(),
+          false,
+          new BadRequestException(),
+        ),
+      ).toBe('500');
+    });
+    it('should return a 200 in green', () => {
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
+        color.green(200),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The WsParser is now written in its entirity. There are a few hardcoded values, though those could be
overriden by dev if they choose by extending the parser itself. Tests are written (P.S. writing
tests to satisfy Socket.io **and** Websocket was almost impossible, but I got it done). Only thing
to do from here is to finish off the microservice parsers :smile:

fix #24