### PR TITLE
ci: gh actions runner now sets the CI=true env variable by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,5 +34,3 @@ jobs:
       run: yarn test:cov
     - name: integration test
       run: yarn test:int
-      env:
-        CI: true


### PR DESCRIPTION
https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/