### PR TITLE
test(ws): fixes test coverage for WsParser

### DIFF
--- a/packages/platform-ws/tests/ws-interceptor.service.spec.ts
+++ b/packages/platform-ws/tests/ws-interceptor.service.spec.ts
@@ -4,7 +4,7 @@ import { Reflector } from '@nestjs/core';
 import { Test } from '@nestjs/testing';
 import { MESSAGE_METADATA } from '@nestjs/websockets/constants';
 import { color } from '@ogma/logger';
-import { WsParser } from '@ogma/platform-ws';
+import { WsParser } from '../src';
 
 describe('WsParser', () => {
   let parser: WsParser;


### PR DESCRIPTION
WsParser was not getting test coverage due to importing from `@ogma/platform-ws` instead of `../src`
which made Jest no longer know where the coverage was coming from.