### PR TITLE
fix(all): fixes OgmaCoreModule not configured

### DIFF
--- a/packages/nestjs-module/src/ogma-core.module.ts
+++ b/packages/nestjs-module/src/ogma-core.module.ts
@@ -91,5 +91,5 @@ export class OgmaCoreModule extends createConfigurableDynamicRootModule<
     WebsocketInterceptorService,
   ],
 }) {
-  static Deferred = OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0);
+  // static Deferred = OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0);
 }

--- a/packages/nestjs-module/src/ogma.module.ts
+++ b/packages/nestjs-module/src/ogma.module.ts
@@ -1,12 +1,12 @@
 import { AsyncModuleConfig } from '@golevelup/nestjs-modules';
 import { DynamicModule, Module, Provider } from '@nestjs/common';
-import { OgmaModuleOptions } from './interfaces';
+import { OgmaModuleOptions, Type } from './interfaces';
 import { createLoggerProviders } from './ogma.provider';
 import { OgmaCoreModule } from './ogma-core.module';
 
 @Module({
-  imports: [OgmaCoreModule.Deferred],
-  exports: [OgmaCoreModule],
+  /* imports: [OgmaCoreModule.Deferred],
+  exports: [OgmaCoreModule], */
 })
 export class OgmaModule {
   static forRoot(options: OgmaModuleOptions): DynamicModule {
@@ -25,10 +25,10 @@ export class OgmaModule {
    *
    * @param context string context for the OgmaService to use in logging
    */
-  static forFeature(context: string | (() => any)): DynamicModule {
+  static forFeature(context: string | (() => any) | Type<any>): DynamicModule {
     const providers: Provider[] = createLoggerProviders(context);
     return {
-      imports: [OgmaCoreModule.Deferred],
+      imports: [OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0)],
       module: OgmaModule,
       providers,
       exports: providers,

--- a/packages/nestjs-module/test/app.module.ts
+++ b/packages/nestjs-module/test/app.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { OgmaModule } from '../src';
+import { AppService } from './app.service';
+
+@Module({
+  imports: [
+    OgmaModule.forRoot({
+      interceptor: false,
+    }),
+    OgmaModule.forFeature(AppService),
+  ],
+  providers: [AppService],
+})
+export class AppModule {}

--- a/packages/nestjs-module/test/app.service.spec.ts
+++ b/packages/nestjs-module/test/app.service.spec.ts
@@ -1,0 +1,36 @@
+import { AppService } from './app.service';
+import { Test } from '@nestjs/testing';
+
+describe('AppService', () => {
+  let service: AppService;
+  let logger: { log: jest.Mock };
+
+  beforeEach(async () => {
+    const modRef = await Test.createTestingModule({
+      providers: [
+        AppService,
+        {
+          provide: 'OGMA_SERVICE:AppService',
+          useValue: {
+            log: jest.fn(),
+          },
+        },
+      ],
+    }).compile();
+    service = modRef.get(AppService);
+    logger = modRef.get<{ log: jest.Mock }>('OGMA_SERVICE:AppService');
+  });
+
+  it('should be truthy', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should return { hello: world }', () => {
+    expect(service.getHello()).toEqual({ hello: 'world' });
+    expect(logger.log).toHaveBeenCalledWith('Say Hello');
+  });
+});
+
+process.on('unhandledRejection', (err) => {
+  throw new Error(err as any);
+});

--- a/packages/nestjs-module/test/app.service.ts
+++ b/packages/nestjs-module/test/app.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { OgmaLogger, OgmaService } from '../src';
+
+@Injectable()
+export class AppService {
+  constructor(@OgmaLogger(AppService) private readonly logger: OgmaService) {}
+
+  getHello() {
+    this.logger.log('Say Hello');
+    return { hello: 'world' };
+  }
+}


### PR DESCRIPTION
Due to how static class members are created in JavaScript and ran at import time rather than call
time `OgmaCoreModule.Deferred` was immediately calling
`OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0)` which was causing Jest and the Node REPL to
throw an error on import of `@ogma/nestjs-module`. This has been remedied and verified by unit
tests, integration tests, and manual tests with imports from the REPL itself.

fix #106