### PR TITLE
feat(module): adds export for `createProviderToken`

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,10 @@
   ],
   "scripts": {
     "preversion": "yarn run format && yarn run lint && yarn build",
+    "postversion": "yarn build:tools && yarn updatePeerDeps",
     "bootstrap": "lerna bootstrap",
     "build": "lerna run build --stream",
+    "build:tools": "tsc -p tools/tsconfig.json",
     "benchmark:all": "yarn benchmark:interceptor && yarn benchmark:logger",
     "benchmark:interceptor": "rimraf benchmarks/interceptor/dist && tsc -p benchmarks/interceptor/tsconfig.json && node benchmarks/interceptor/dist/main.js",
     "benchmark:logger": "rimraf benchmarks/logger/dist && tsc -p benchmarks/logger/tsconfig.json && node benchmarks/logger/dist/index.js",
@@ -47,7 +49,8 @@
     "test:debug": "node --inspect-brk -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "test:int": "jest --config jest-integration.config.js",
-    "test:int:debug": "node --inspect-brk -r ts-node/register node_modules/.bin/jest --runInBand --config jest-integration.config.js"
+    "test:int:debug": "node --inspect-brk -r ts-node/register node_modules/.bin/jest --runInBand --config jest-integration.config.js",
+    "updatePeerDeps": "node tools/peer-update.js"
   },
   "devDependencies": {
     "@commitlint/cli": "^9.1.1",

--- a/packages/nestjs-module/src/index.ts
+++ b/packages/nestjs-module/src/index.ts
@@ -3,4 +3,5 @@ export * from './interceptor/ogma.interceptor';
 export * from './interceptor/providers/abstract-interceptor.service';
 export * from './interfaces/ogma-options.interface';
 export * from './ogma.module';
+export { createProviderToken } from './ogma.provider';
 export * from './ogma.service';

--- a/tools/peer-update.js
+++ b/tools/peer-update.js
@@ -1,0 +1,53 @@
+'use strict';
+Object.defineProperty(exports, '__esModule', { value: true });
+const logger_1 = require('@ogma/logger');
+const fs_1 = require('fs');
+const versionMap = {};
+function readDirectory(dir) {
+  return fs_1.readdirSync(dir);
+}
+function getPackageJSON(packageName) {
+  const packageString = fs_1
+    .readFileSync(`./packages/${packageName}/package.json`)
+    .toString();
+  return JSON.parse(packageString);
+}
+function populateVersionMap(packageObject) {
+  versionMap[packageObject.name] = packageObject.version;
+  return packageObject;
+}
+function hasOgmaPeerDep(packageObject) {
+  return packageObject.peerDependencies
+    ? Object.keys(packageObject.peerDependencies).some(
+        (key) => !!versionMap[key],
+      )
+    : false;
+}
+function updatePeerDep(packageObject) {
+  Object.keys(packageObject.peerDependencies)
+    .filter((key) => !!versionMap[key])
+    .forEach(
+      (key) => (packageObject.peerDependencies[key] = '^' + versionMap[key]),
+    );
+  return packageObject;
+}
+function updatePackageJSON(packageObject) {
+  fs_1.writeFileSync(
+    `./packages/${packageObject.name.replace('@ogma/', '')}/package.json`,
+    Buffer.from(JSON.stringify(packageObject, null, 2) + '\n'),
+  );
+  console.log(
+    `Updated ${logger_1.color.blue('package.json')} for ${logger_1.color.green(
+      packageObject.name,
+    )}`,
+  );
+}
+function bootstrap() {
+  readDirectory('./packages')
+    .map(getPackageJSON)
+    .map(populateVersionMap)
+    .filter(hasOgmaPeerDep)
+    .map(updatePeerDep)
+    .forEach(updatePackageJSON);
+}
+bootstrap();

--- a/tools/peer-update.ts
+++ b/tools/peer-update.ts
@@ -1,0 +1,67 @@
+import { color } from '@ogma/logger';
+import { readdirSync, readFileSync, writeFileSync } from 'fs';
+
+const versionMap: Record<string, string> = {};
+
+interface packageJSON {
+  version: string;
+  dependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
+  name: string;
+}
+
+function readDirectory(dir: string): string[] {
+  return readdirSync(dir);
+}
+
+function getPackageJSON(packageName: string): packageJSON {
+  const packageString = readFileSync(
+    `./packages/${packageName}/package.json`,
+  ).toString();
+  return JSON.parse(packageString);
+}
+
+function populateVersionMap(packageObject: packageJSON): packageJSON {
+  versionMap[packageObject.name] = packageObject.version;
+  return packageObject;
+}
+
+function hasOgmaPeerDep(packageObject: packageJSON): boolean {
+  return packageObject.peerDependencies
+    ? Object.keys(packageObject.peerDependencies).some(
+        (key) => !!versionMap[key],
+      )
+    : false;
+}
+
+function updatePeerDep(packageObject: packageJSON): packageJSON {
+  Object.keys(packageObject.peerDependencies)
+    .filter((key) => !!versionMap[key])
+    .forEach(
+      (key) => (packageObject.peerDependencies[key] = '^' + versionMap[key]),
+    );
+  return packageObject;
+}
+
+function updatePackageJSON(packageObject: packageJSON): void {
+  writeFileSync(
+    `./packages/${packageObject.name.replace('@ogma/', '')}/package.json`,
+    Buffer.from(JSON.stringify(packageObject, null, 2) + '\n'),
+  );
+  console.log(
+    `Updated ${color.blue('package.json')} for ${color.green(
+      packageObject.name,
+    )}`,
+  );
+}
+
+function bootstrap() {
+  readDirectory('./packages')
+    .map(getPackageJSON)
+    .map(populateVersionMap)
+    .filter(hasOgmaPeerDep)
+    .map(updatePeerDep)
+    .forEach(updatePackageJSON);
+}
+
+bootstrap();

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./",
+    "baseUrl": "./",
+    "declaration": false
+  }
+}


### PR DESCRIPTION
The export for the `createProviderToken` can be made use of in tests or manual usages to get the
Ogma provider token (like in factories) so that developers no longer need to know what the
dependency injection token is.