### PR TITLE
Feat/meta

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,7 @@ name: CI
 on:
   pull_request:
     branches:
-      - 'master'
-      - 'monorepo'
+      - 'main'
   push:
     branches:
       - '*'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,10 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [main]
   schedule:
     - cron: '0 0 * * *'
 

--- a/.prettierrc
+++ b/.prettierrc
@@ -2,6 +2,7 @@
   "singleQuote": true,
   "arrowParens": "always",
   "trailingComma": "all",
+  "printWidth": 100,
   "overrides": [
     {
       "files": "*.md",

--- a/integration/src/grpc/client/grpc-client.controller.ts
+++ b/integration/src/grpc/client/grpc-client.controller.ts
@@ -1,10 +1,4 @@
-import {
-  Controller,
-  Get,
-  Inject,
-  OnModuleInit,
-  UseFilters,
-} from '@nestjs/common';
+import { Controller, Get, Inject, OnModuleInit, UseFilters } from '@nestjs/common';
 import { ClientGrpc } from '@nestjs/microservices';
 import { ExceptionFilter } from './exception.filter';
 import { HelloService } from './hello-service.interface';

--- a/integration/src/kafka/client/kafka-client.controller.ts
+++ b/integration/src/kafka/client/kafka-client.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  Get,
-  Inject,
-  OnModuleDestroy,
-  OnModuleInit,
-  UseFilters,
-} from '@nestjs/common';
+import { Controller, Get, Inject, OnModuleDestroy, OnModuleInit, UseFilters } from '@nestjs/common';
 import { ClientKafka } from '@nestjs/microservices';
 import { ExceptionFilter } from './exception.filter';
 
@@ -14,9 +7,7 @@ export class KafkaClientController implements OnModuleInit, OnModuleDestroy {
   constructor(@Inject('KAFKA_SERVICE') private readonly kafka: ClientKafka) {}
 
   async onModuleInit() {
-    ['hello', 'error', 'skip'].forEach((key) =>
-      this.kafka.subscribeToResponseOf(`say.${key}`),
-    );
+    ['hello', 'error', 'skip'].forEach((key) => this.kafka.subscribeToResponseOf(`say.${key}`));
   }
 
   onModuleDestroy() {

--- a/integration/src/nested-module/app.controller.ts
+++ b/integration/src/nested-module/app.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppService } from '../../../benchmarks/interceptor/dist/app.service';
+
+@Controller()
+export class AppController {
+  constructor(private readonly appService: AppService) {}
+
+  @Get()
+  sayHello() {
+    return this.appService.getHello();
+  }
+}

--- a/integration/src/nested-module/app.controller.ts
+++ b/integration/src/nested-module/app.controller.ts
@@ -1,5 +1,5 @@
 import { Controller, Get } from '@nestjs/common';
-import { AppService } from '../../../benchmarks/interceptor/dist/app.service';
+import { AppService } from './app.service';
 
 @Controller()
 export class AppController {

--- a/integration/src/nested-module/app.module.ts
+++ b/integration/src/nested-module/app.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { OgmaModule } from '@ogma/nestjs-module';
+import { AppController } from './app.controller';
+import { AppService } from './app.service';
+import { LoggerModule } from './logger.module';
+
+@Module({
+  imports: [LoggerModule, OgmaModule.forFeature(AppService)],
+  controllers: [AppController],
+  providers: [AppService],
+})
+export class NestedModule {}

--- a/integration/src/nested-module/app.service.ts
+++ b/integration/src/nested-module/app.service.ts
@@ -1,0 +1,12 @@
+import { Injectable } from '@nestjs/common';
+import { OgmaLogger, OgmaService } from '@ogma/nestjs-module';
+
+@Injectable()
+export class AppService {
+  constructor(@OgmaLogger(AppService) private readonly logger: OgmaService) {}
+
+  getHello() {
+    this.logger.log('Hello NestedModule');
+    return { hello: 'World' };
+  }
+}

--- a/integration/src/nested-module/logger.module.ts
+++ b/integration/src/nested-module/logger.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { OgmaModule } from '@ogma/nestjs-module';
+
+@Module({
+  imports: [
+    OgmaModule.forRoot({
+      service: {
+        application: 'NestedModule',
+      },
+      interceptor: false,
+    }),
+  ],
+})
+export class LoggerModule {}

--- a/integration/src/rpc/client/rpc-client.controller.ts
+++ b/integration/src/rpc/client/rpc-client.controller.ts
@@ -10,8 +10,7 @@ import { ClientProxy } from '@nestjs/microservices';
 import { ExceptionFilter } from './exception.filter';
 
 @Controller()
-export class RpcClientController
-  implements OnApplicationBootstrap, OnApplicationShutdown {
+export class RpcClientController implements OnApplicationBootstrap, OnApplicationShutdown {
   constructor(@Inject('RPC-SERVICE') private readonly micro: ClientProxy) {}
 
   async onApplicationBootstrap() {

--- a/integration/src/ws/ws.gateway.ts
+++ b/integration/src/ws/ws.gateway.ts
@@ -1,9 +1,5 @@
 import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
-import {
-  BadRequestException,
-  UseFilters,
-  UseInterceptors,
-} from '@nestjs/common';
+import { BadRequestException, UseFilters, UseInterceptors } from '@nestjs/common';
 import { OgmaInterceptor, OgmaSkip } from '@ogma/nestjs-module';
 import { AppService } from '../app.service';
 import { SimpleObject } from '../simple-object.model';

--- a/integration/test/gql.spec.ts
+++ b/integration/test/gql.spec.ts
@@ -1,20 +1,11 @@
 import { HttpServer, INestApplication } from '@nestjs/common';
 import { ExpressAdapter } from '@nestjs/platform-express';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
-import {
-  AbstractInterceptorService,
-  OgmaInterceptor,
-  Type,
-} from '@ogma/nestjs-module';
+import { AbstractInterceptorService, OgmaInterceptor, Type } from '@ogma/nestjs-module';
 import { GraphQLParser } from '@ogma/platform-graphql';
 import { GraphQLFastifyParser } from '@ogma/platform-graphql-fastify';
 import { GqlModule } from '../src/gql/gql.module';
-import {
-  createTestModule,
-  getInterceptor,
-  gqlPromise,
-  serviceOptionsFactory,
-} from './utils';
+import { createTestModule, getInterceptor, gqlPromise, serviceOptionsFactory } from './utils';
 import { color } from '@ogma/logger';
 
 describe.each`
@@ -78,34 +69,18 @@ describe.each`
         ${'query'}    | ${'getQuery'}    | ${color.green(200)}
         ${'query'}    | ${'getError'}    | ${color.yellow(400)}
         ${'mutation'} | ${'getMutation'} | ${color.green(200)}
-      `(
-        '$type $name',
-        ({
-          type,
-          name,
-          status,
-        }: {
-          type: string;
-          name: string;
-          status: string;
-        }) => {
-          it('should log the call', async () => {
-            await gqlPromise(baseUrl, {
-              query: `${type} ${name}{ ${name}{ hello }}`,
-            });
-            const logObject = logSpy.mock.calls[0][0];
-            const requestId = logSpy.mock.calls[0][2];
-            expect(logObject).toBeALogObject(
-              type,
-              '/graphql',
-              'HTTP/1.1',
-              status,
-            );
-            expect(typeof requestId).toBe('string');
-            expect(requestId).toHaveLength(16);
+      `('$type $name', ({ type, name, status }: { type: string; name: string; status: string }) => {
+        it('should log the call', async () => {
+          await gqlPromise(baseUrl, {
+            query: `${type} ${name}{ ${name}{ hello }}`,
           });
-        },
-      );
+          const logObject = logSpy.mock.calls[0][0];
+          const requestId = logSpy.mock.calls[0][2];
+          expect(logObject).toBeALogObject(type, '/graphql', 'HTTP/1.1', status);
+          expect(typeof requestId).toBe('string');
+          expect(requestId).toHaveLength(16);
+        });
+      });
       describe('getSkip', () => {
         it('should make the call but skip the log', async () => {
           await gqlPromise(baseUrl, {

--- a/integration/test/grpc.spec.ts
+++ b/integration/test/grpc.spec.ts
@@ -69,15 +69,7 @@ describe('GrpcParser', () => {
       ${'/error'} | ${color.red(500)}   | ${'SayError'}
     `(
       '$url call',
-      async ({
-        url,
-        status,
-        endpoint,
-      }: {
-        url: string;
-        status: string;
-        endpoint: string;
-      }) => {
+      async ({ url, status, endpoint }: { url: string; status: string; endpoint: string }) => {
         await httpPromise(baseUrl + url);
         expect(logSpy).toBeCalledTimes(1);
         const logObject = logSpy.mock.calls[0][0];

--- a/integration/test/http.spec.ts
+++ b/integration/test/http.spec.ts
@@ -1,11 +1,7 @@
 import { HttpServer, INestApplication } from '@nestjs/common';
 import { ExpressAdapter } from '@nestjs/platform-express';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
-import {
-  AbstractInterceptorService,
-  OgmaInterceptor,
-  Type,
-} from '@ogma/nestjs-module';
+import { AbstractInterceptorService, OgmaInterceptor, Type } from '@ogma/nestjs-module';
 import { color } from '@ogma/logger';
 import { ExpressParser } from '@ogma/platform-express';
 import { FastifyParser } from '@ogma/platform-fastify';
@@ -66,11 +62,7 @@ describe.each`
         logSpy.mockClear();
       });
 
-      function expectLogObject(
-        method: string,
-        endpoint: string,
-        status: string,
-      ) {
+      function expectLogObject(method: string, endpoint: string, status: string) {
         const logObject = logSpy.mock.calls[0][0];
         expect(logObject).toBeALogObject(method, endpoint, 'HTTP/1.1', status);
         expect(logSpy).toHaveBeenCalledTimes(1);

--- a/integration/test/nested-module.spec.ts
+++ b/integration/test/nested-module.spec.ts
@@ -1,0 +1,37 @@
+import { INestApplication } from '@nestjs/common';
+import { Test } from '@nestjs/testing';
+import { createProviderToken, OgmaService } from '@ogma/nestjs-module';
+import { NestedModule } from '../src/nested-module/app.module';
+import { AppService } from '../src/nested-module/app.service';
+import { httpPromise } from './utils';
+
+describe('NestedModule', () => {
+  let app: INestApplication;
+  let ogmaService: OgmaService;
+
+  beforeAll(async () => {
+    const modRef = await Test.createTestingModule({
+      imports: [NestedModule],
+    }).compile();
+    app = modRef.createNestApplication();
+    ogmaService = modRef.get(createProviderToken(AppService.name));
+    await app.listen(0);
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  describe('call endpoint', () => {
+    let appUrl: string;
+    beforeAll(async () => {
+      appUrl = await app.getUrl();
+    });
+    it('should instantiate and call /', async () => {
+      const spy = jest.spyOn(ogmaService, 'log');
+      await httpPromise(appUrl);
+      expect(spy).toHaveBeenCalledTimes(1);
+      expect(spy).toHaveBeenCalledWith('Hello NestedModule');
+    });
+  });
+});

--- a/integration/test/rpc.spec.ts
+++ b/integration/test/rpc.spec.ts
@@ -10,11 +10,7 @@ import {
 } from '@nestjs/microservices';
 import { Test } from '@nestjs/testing';
 import { color } from '@ogma/logger';
-import {
-  AbstractInterceptorService,
-  OgmaInterceptor,
-  Type,
-} from '@ogma/nestjs-module';
+import { AbstractInterceptorService, OgmaInterceptor, Type } from '@ogma/nestjs-module';
 import { MqttParser } from '@ogma/platform-mqtt';
 import { NatsParser } from '@ogma/platform-nats';
 import { RabbitMqParser } from '@ogma/platform-rabbitmq';
@@ -136,12 +132,7 @@ describe.each`
           const logObject = logSpy.mock.calls[0][0];
           const requestId = logSpy.mock.calls[0][2];
 
-          expect(logObject).toBeALogObject(
-            server,
-            JSON.stringify(endpoint),
-            protocol,
-            status,
-          );
+          expect(logObject).toBeALogObject(server, JSON.stringify(endpoint), protocol, status);
           expect(typeof requestId).toBe('string');
           expect(requestId).toHaveLength(16);
         },

--- a/integration/test/utils/getInterceptor.ts
+++ b/integration/test/utils/getInterceptor.ts
@@ -2,16 +2,14 @@ import { INestApplication, INestMicroservice } from '@nestjs/common';
 import { OgmaInterceptor } from '@ogma/nestjs-module';
 
 // just trust me... I hate this...
-export function getInterceptor(
-  app: INestApplication | INestMicroservice,
-): OgmaInterceptor {
+export function getInterceptor(app: INestApplication | INestMicroservice): OgmaInterceptor {
   return app.get<OgmaInterceptor>(
     Array.from((app as any).container.getModules().values())
       .filter((module: any) => module.metatype.name === 'RootTestModule')
       .map((module: any) => {
-        return Array.from<string>(
-          module.providers.keys(),
-        ).filter((prov: string) => prov.includes('APP_INTERCEPTOR'))[0];
+        return Array.from<string>(module.providers.keys()).filter((prov: string) =>
+          prov.includes('APP_INTERCEPTOR'),
+        )[0];
       })[0],
   );
 }

--- a/integration/test/utils/index.ts
+++ b/integration/test/utils/index.ts
@@ -10,9 +10,6 @@ export * from './gql-promise';
 export * from './http-promise';
 export * from './ws-promise';
 export const hello = JSON.stringify({ hello: 'world' });
-export const serviceOptionsFactory = (
-  app: string,
-  json = false,
-): OgmaServiceOptions => {
+export const serviceOptionsFactory = (app: string, json = false): OgmaServiceOptions => {
   return { application: app, stream, json };
 };

--- a/integration/test/utils/matcher.ts
+++ b/integration/test/utils/matcher.ts
@@ -13,27 +13,18 @@ declare global {
   namespace jest {
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     interface Matchers<R> {
-      toBeALogObject(
-        method: string,
-        endpoint: string,
-        protocol: string,
-        status: string,
-      ): R;
+      toBeALogObject(method: string, endpoint: string, protocol: string, status: string): R;
     }
   }
 }
 
 const expectMessage = (field: string, expected: string, actual: string) =>
-  `Expected ${field} to be ${color.green(expected)} but got ${color.red(
-    actual,
-  )}.\n`;
+  `Expected ${field} to be ${color.green(expected)} but got ${color.red(actual)}.\n`;
 
 const returnMessage = (pass: boolean, message: string) => ({
   pass,
   message: () =>
-    pass
-      ? 'This matcher is not made to work with negation. Please do not use it'
-      : message,
+    pass ? 'This matcher is not made to work with negation. Please do not use it' : message,
 });
 
 const doTest = (
@@ -98,17 +89,9 @@ expect.extend({
       recTime: string,
       recSize: string;
     if (typeof received === 'string') {
-      [
-        recIp,
-        ,
-        recMethod,
-        recEndpoint,
-        recProto,
-        recStatus,
-        recTime,
-        ,
-        recSize,
-      ] = received.split(' ');
+      [recIp, , recMethod, recEndpoint, recProto, recStatus, recTime, , recSize] = received.split(
+        ' ',
+      );
     } else {
       ({
         callerAddress: recIp as any,

--- a/integration/test/ws.spec.ts
+++ b/integration/test/ws.spec.ts
@@ -3,23 +3,13 @@ import { IoAdapter } from '@nestjs/platform-socket.io';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { Test } from '@nestjs/testing';
 import { color } from '@ogma/logger';
-import {
-  AbstractInterceptorService,
-  OgmaInterceptor,
-  Type,
-} from '@ogma/nestjs-module';
+import { AbstractInterceptorService, OgmaInterceptor, Type } from '@ogma/nestjs-module';
 import { SocketIOParser } from '@ogma/platform-socket.io';
 import { WsParser } from '@ogma/platform-ws';
 import Io from 'socket.io-client';
 import WebSocket from 'ws';
 import { WsModule } from '../src/ws/ws.module';
-import {
-  createConnection,
-  hello,
-  serviceOptionsFactory,
-  wsClose,
-  wsPromise,
-} from './utils';
+import { createConnection, hello, serviceOptionsFactory, wsClose, wsPromise } from './utils';
 
 describe.each`
   adapter      | server         | parser            | client                                 | protocol  | sendMethod | serializer                                                 | deserializer
@@ -96,24 +86,16 @@ describe.each`
         message      | status
         ${'message'} | ${color.green(200)}
         ${'throw'}   | ${color.red(500)}
-      `(
-        '$message',
-        async ({ message, status }: { message: string; status: string }) => {
-          await wsPromise(ws, serializer(message), sendMethod);
-          expect(logSpy).toHaveBeenCalledTimes(1);
-          const logObject = logSpy.mock.calls[0][0];
-          const requestId = logSpy.mock.calls[0][2];
+      `('$message', async ({ message, status }: { message: string; status: string }) => {
+        await wsPromise(ws, serializer(message), sendMethod);
+        expect(logSpy).toHaveBeenCalledTimes(1);
+        const logObject = logSpy.mock.calls[0][0];
+        const requestId = logSpy.mock.calls[0][2];
 
-          expect(logObject).toBeALogObject(
-            server.toLowerCase(),
-            message,
-            'WS',
-            status,
-          );
-          expect(typeof requestId).toBe('string');
-          expect(requestId).toHaveLength(16);
-        },
-      );
+        expect(logObject).toBeALogObject(server.toLowerCase(), message, 'WS', status);
+        expect(typeof requestId).toBe('string');
+        expect(requestId).toHaveLength(16);
+      });
       it('should get the data from skip but not log', async () => {
         const data = await wsPromise(ws, serializer('skip'), sendMethod);
         expect(data).toEqual(deserializer(hello));

--- a/packages/logger/src/command/command.ts
+++ b/packages/logger/src/command/command.ts
@@ -21,9 +21,7 @@ function wrapInParens(message: string): string {
 }
 
 function isOgmaFormat(log: Record<string, unknown>): log is OgmaLog {
-  return standardKeys.every((key) =>
-    Object.prototype.hasOwnProperty.call(log, key),
-  );
+  return standardKeys.every((key) => Object.prototype.hasOwnProperty.call(log, key));
 }
 
 function getColor(level: keyof typeof LogLevel): Color {
@@ -125,19 +123,14 @@ function writeLog(log: OgmaLog, useColor: boolean): void {
   process.stdout.write(Buffer.from(logMessage));
 }
 
-async function rehydrate(
-  fileName: string,
-  useColor: boolean = process.stdout.isTTY,
-) {
+async function rehydrate(fileName: string, useColor: boolean = process.stdout.isTTY) {
   const context = await readPassedFile(fileName);
   const logs = context.split('\n').filter((log) => log);
   if (!logs.every(ogmaFormatCheck)) {
     process.stderr.write(messages.badFormat);
     return process.exit(1);
   }
-  logs
-    .map((log) => JSON.parse(log))
-    .forEach((log: OgmaLog) => writeLog(log, useColor));
+  logs.map((log) => JSON.parse(log)).forEach((log: OgmaLog) => writeLog(log, useColor));
 }
 
 function missingFile() {

--- a/packages/logger/src/command/messages.ts
+++ b/packages/logger/src/command/messages.ts
@@ -4,5 +4,4 @@ export const badFormat =
 export const missingFile = 'Log file to rehydrate must be specified.\n';
 export const usage = `There was a problem with the given arguments.
 To use the ogma command, please pass the file name with respect to <root> and an optional flag "--color=true|false".\n`;
-export const tooManyArgs =
-  'Please only pass two arguments to the ogma command.\n';
+export const tooManyArgs = 'Please only pass two arguments to the ogma command.\n';

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,4 +1,4 @@
 export { LogLevel } from './enums';
-export * from './interfaces';
+export { OgmaOptions, OgmaPrintOptions } from './interfaces';
 export * from './logger';
-export * from './utils';
+export { color } from './utils';

--- a/packages/logger/src/interfaces/index.ts
+++ b/packages/logger/src/interfaces/index.ts
@@ -1,1 +1,5 @@
+export * from './ogma-log';
 export * from './ogma-options';
+export * from './ogma-print-options';
+export * from './ogma-stream';
+export * from './print-message-options';

--- a/packages/logger/src/interfaces/ogma-options.ts
+++ b/packages/logger/src/interfaces/ogma-options.ts
@@ -1,13 +1,14 @@
 import { LogLevel } from '../enums';
+import { OgmaStream } from './ogma-stream';
 
 export interface OgmaOptions {
   logLevel: keyof typeof LogLevel;
   color: boolean;
-  stream: Partial<NodeJS.WritableStream | NodeJS.WriteStream> &
-    Pick<NodeJS.WritableStream, 'write'>;
+  stream: OgmaStream;
   json: boolean;
   context: string;
   application: string;
+  verbose?: boolean;
   [index: string]: any;
 }
 
@@ -18,4 +19,5 @@ export const OgmaDefaults: OgmaOptions = {
   json: false,
   context: '',
   application: '',
+  verbose: false,
 };

--- a/packages/logger/src/interfaces/ogma-print-options.ts
+++ b/packages/logger/src/interfaces/ogma-print-options.ts
@@ -1,0 +1,6 @@
+export interface OgmaPrintOptions {
+  context?: string;
+  application?: string;
+  correlationId?: string;
+  [key: string]: unknown;
+}

--- a/packages/logger/src/interfaces/ogma-stream.ts
+++ b/packages/logger/src/interfaces/ogma-stream.ts
@@ -1,0 +1,4 @@
+export interface OgmaStream {
+  write: (message: any) => unknown;
+  hasColors?: () => boolean;
+}

--- a/packages/logger/src/interfaces/print-message-options.ts
+++ b/packages/logger/src/interfaces/print-message-options.ts
@@ -1,0 +1,10 @@
+import { LogLevel } from '../enums';
+
+export interface PrintMessageOptions {
+  level: LogLevel;
+  formattedLevel: string;
+  application?: string;
+  context?: string;
+  correlationId?: string;
+  [key: string]: unknown;
+}

--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -1,30 +1,8 @@
 import { hostname } from 'os';
 import { Color, LogLevel } from '../enums';
-import { OgmaDefaults, OgmaOptions } from '../interfaces';
-import { colorize } from '../utils/colorize';
-
-interface JSONLog {
-  level: keyof typeof LogLevel;
-  time: string;
-  message?: any;
-  context?: string;
-  pid: number;
-  application?: string;
-  hostname: string;
-  requestId?: string;
-}
-
-interface PrintMessageOptions {
-  level: LogLevel;
-  formattedLevel: string;
-  application?: string;
-  context?: string;
-  requestId?: string;
-}
-
-function isNil(val: any): boolean {
-  return val === undefined || val === null || val === '';
-}
+import { OgmaDefaults, OgmaLog, OgmaOptions, PrintMessageOptions } from '../interfaces';
+import { OgmaPrintOptions } from '../interfaces/ogma-print-options';
+import { colorize, isNil } from '../utils';
 
 export class Ogma {
   private options: OgmaOptions;
@@ -36,16 +14,6 @@ export class Ogma {
 
   [index: string]: any;
 
-  /**
-   * Ogma constructor. Creates a new instance of Ogma
-   *
-   * @param options Partial of OgmaOptions which you want to use for your Ogma instance.
-   * Options include:
-   *
-   * * logLevel: The level of logs you want to show. Passed as a string
-   * * color: `true` if you want color, `false` if you don't. If your terminal does not allow color, this option will be ignored
-   * * stream: an object with a `write(message: any) => void` property. Useful if you want to log to a file instead of the console
-   */
   constructor(options?: Partial<OgmaOptions>) {
     if (options?.logLevel) {
       options.logLevel = options.logLevel.toUpperCase() as keyof typeof LogLevel;
@@ -76,6 +44,11 @@ export class Ogma {
       logString = this.formatStream(message, options);
     }
     this.options.stream.write(`${logString}\n`);
+    if (this.options.verbose && !this.options.json) {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { context, application, correlationId, level, formattedLevel, ...meta } = options;
+      this.options.stream.write(this.formatStream(meta, options));
+    }
   }
 
   private circularReplacer(): (key: string, value: any) => string {
@@ -99,12 +72,7 @@ export class Ogma {
 
   private toColor(level: LogLevel, color: Color): string {
     const levelString = this.wrapInBrackets(LogLevel[level]).padEnd(7);
-    return colorize(
-      levelString,
-      color,
-      this.options.color,
-      this.options.stream,
-    );
+    return colorize(levelString, color, this.options.color, this.options.stream);
   }
 
   private wrapInBrackets(valueToBeWrapper: string): string {
@@ -113,15 +81,16 @@ export class Ogma {
 
   private formatJSON(
     message: any,
-    { application, requestId, context, level }: PrintMessageOptions,
+    { application = '', correlationId = '', context = '', level, ...meta }: PrintMessageOptions,
   ): string {
-    let json: Partial<JSONLog> = {
+    let json: Partial<OgmaLog> = {
       time: this.getTimestamp(),
     };
+    delete meta.formattedLevel;
     json.application = application || this.options.application || undefined;
     json.pid = this.pid;
     json.hostname = this.hostname;
-    json.requestId = requestId;
+    json.correlationId = correlationId;
     json.context = context || this.options.context || undefined;
     json.level = LogLevel[level] as keyof typeof LogLevel;
     if (typeof message === 'object') {
@@ -130,220 +99,97 @@ export class Ogma {
     } else {
       json.message = message;
     }
+    if (meta && Object.keys(meta).length) {
+      json.meta = meta;
+    }
     return JSON.stringify(json, this.circularReplacer());
   }
 
   private formatStream(
     message: any,
-    { application, requestId, formattedLevel, context }: PrintMessageOptions,
+    { application = '', correlationId = '', formattedLevel, context = '' }: PrintMessageOptions,
   ): string {
     if (typeof message === 'object') {
       message = '\n' + JSON.stringify(message, this.circularReplacer(), 2);
     }
-    application = this.toStreamColor(
-      application || this.options.application,
-      Color.YELLOW,
-    );
+    application = this.toStreamColor(application || this.options.application, Color.YELLOW);
     context = this.toStreamColor(context || this.options.context, Color.CYAN);
 
     const hostname = this.toStreamColor(this.hostname, Color.MAGENTA);
     const timestamp = this.wrapInBrackets(this.getTimestamp());
-    return `${timestamp} ${hostname} ${application}${this.pid} ${requestId}${context}${formattedLevel}| ${message}`;
+    return `${timestamp} ${hostname} ${application} ${this.pid} ${correlationId}${context}${formattedLevel}| ${message}`;
   }
 
   private toStreamColor(value: string, color: Color): string {
     if (!value) {
       return '';
     }
-    return colorize(
-      this.wrapInBrackets(value),
-      color,
-      this.options.color,
-      this.options.stream,
-    );
+    return colorize(this.wrapInBrackets(value), color, this.options.color, this.options.stream);
   }
 
   private getTimestamp(): string {
     return new Date().toISOString();
   }
 
-  /**
-   * Silly log level. Prints SILLY in purple when color is enabled
-   *
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public silly(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public silly(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.SILLY,
       formattedLevel: this.toColor(LogLevel.SILLY, Color.MAGENTA),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Verbose log level. Prints FINE in green when color is enabled
-   *
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public verbose(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public verbose(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.VERBOSE,
       formattedLevel: this.toColor(LogLevel.VERBOSE, Color.GREEN),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Debug log level. Prints DEBUG in blue when color is enabled
-   *
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public debug(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public debug(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.DEBUG,
       formattedLevel: this.toColor(LogLevel.DEBUG, Color.BLUE),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Info log level. Prints INFO in cyan when color is enabled.
-   *
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public info(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public info(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.INFO,
       formattedLevel: this.toColor(LogLevel.INFO, Color.CYAN),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Warn log level. Prints WARN in yellow when color is enabled.
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public warn(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public warn(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.WARN,
       formattedLevel: this.toColor(LogLevel.WARN, Color.YELLOW),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Error log level. Prints ERROR in red when color is enabled.
-   *
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public error(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public error(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.ERROR,
       formattedLevel: this.toColor(LogLevel.ERROR, Color.RED),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Fatal log level. Prints FATAL in red when color is enabled.
-   *
-   * @param message the message to print out. Can also be a JSON object
-   * @param context the context to add the the log. Can be used to override class setting
-   * @param application the application name to add to the log. Can be used to override class setting
-   * @param requestId id of request
-   */
-  public fatal(
-    message: any,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
+  public fatal(message: any, meta?: OgmaPrintOptions): void {
     this.printMessage(message, {
       level: LogLevel.FATAL,
       formattedLevel: this.toColor(LogLevel.FATAL, Color.RED),
-      application,
-      context,
-      requestId,
+      ...meta,
     });
   }
 
-  /**
-   * Error printing utility method. Made to make things easier
-   *
-   * @param error The error that is to be printed. The name, message, and stack trace will be printed
-   * at the Error, Warn, and Verbose log level respectively
-   * @param context string context of log
-   * @param application string name of appliction
-   * @param requestId string id of an request
-   */
-  public printError(
-    error: Error,
-    context?: string,
-    application?: string,
-    requestId?: string,
-  ): void {
-    this.error(error.name, context, application, requestId);
-    this.warn(error.message, context, application, requestId);
-    this.verbose('\n' + error.stack, context, application, requestId);
+  public printError(error: Error, meta?: OgmaPrintOptions): void {
+    this.error(error.name, meta);
+    this.warn(error.message, meta);
+    this.verbose('\n' + error.stack, meta);
   }
 }

--- a/packages/logger/src/utils/colorize.ts
+++ b/packages/logger/src/utils/colorize.ts
@@ -1,4 +1,5 @@
 import { Color } from '../enums';
+import { OgmaStream } from '../interfaces';
 import { OgmaSimpleType } from '../types';
 
 const ESC = '\x1B';
@@ -7,13 +8,9 @@ export function colorize(
   value: OgmaSimpleType,
   color: Color = Color.WHITE,
   useColor = true,
-  stream: Partial<NodeJS.WritableStream | NodeJS.WriteStream> = process.stdout,
+  stream: OgmaStream = process.stdout,
 ): string {
-  if (
-    (stream as NodeJS.WriteStream).hasColors &&
-    (stream as NodeJS.WriteStream).hasColors() &&
-    useColor
-  ) {
+  if (stream.hasColors && stream.hasColors() && useColor) {
     value = `${ESC}[3${color}m${value}${ESC}[0m`;
   }
   return value.toString();

--- a/packages/logger/src/utils/index.ts
+++ b/packages/logger/src/utils/index.ts
@@ -1,1 +1,3 @@
 export * from './color';
+export * from './colorize';
+export * from './is-nil';

--- a/packages/logger/src/utils/is-nil.ts
+++ b/packages/logger/src/utils/is-nil.ts
@@ -1,0 +1,3 @@
+export function isNil(val: unknown): boolean {
+  return val === undefined || val === null || val === '';
+}

--- a/packages/logger/test/colorize.spec.ts
+++ b/packages/logger/test/colorize.spec.ts
@@ -55,9 +55,7 @@ describe('it should not print colors with a stream that does not support colors'
 
 describe('ColorizeCLI', () => {
   it('should print with color', () => {
-    expect(colorizeCLI('hello', Color.BLUE, true)).toBe(
-      `\u001b[3${Color.BLUE}mhello\u001b[0m`,
-    );
+    expect(colorizeCLI('hello', Color.BLUE, true)).toBe(`\u001b[3${Color.BLUE}mhello\u001b[0m`);
   });
   it('should print without color', () => {
     expect(colorizeCLI('hello', Color.BLUE, false)).toBe('hello');

--- a/packages/logger/test/command.fixtures.ts
+++ b/packages/logger/test/command.fixtures.ts
@@ -26,15 +26,7 @@ export interface ExpectedOgmaOutput {
   [key: string]: string;
 }
 
-export const logKeys = [
-  'silly',
-  'fine',
-  'debug',
-  'info',
-  'warn',
-  'error',
-  'fatal',
-];
+export const logKeys = ['silly', 'fine', 'debug', 'info', 'warn', 'error', 'fatal'];
 
 const time = '2020-01-14T05:47:48.091Z';
 const pid = 13940;
@@ -94,9 +86,7 @@ export const fullJSON: OgmaLogSet = {
 };
 
 function hydrateNoAppNoConFactory(level: string): string {
-  return `[${time}] ${color.magenta(
-    '[' + host + ']',
-  )} ${pid} ${level}| ${JSON.stringify(hello)}\n`;
+  return `[${time}] ${color.magenta('[' + host + ']')} ${pid} ${level}| ${JSON.stringify(hello)}\n`;
 }
 
 const hydratedNoAppNoCon: ExpectedOgmaOutput = {
@@ -144,9 +134,7 @@ const hydratedNoApp: ExpectedOgmaOutput = {
 function hydrateFullFactory(level: string): string {
   return `[${time}] ${color.magenta('[' + host + ']')} ${color.yellow(
     '[' + application + ']',
-  )} ${pid} ${color.cyan('[' + context + ']')} ${level}| ${JSON.stringify(
-    hello,
-  )}\n`;
+  )} ${pid} ${color.cyan('[' + context + ']')} ${level}| ${JSON.stringify(hello)}\n`;
 }
 
 const hydratedFull: ExpectedOgmaOutput = {
@@ -174,9 +162,7 @@ const hydratedNoAppNoConNoColor: ExpectedOgmaOutput = {
 };
 
 function hydrateNoConNoColorFactory(level: string): string {
-  return `[${time}] [${host}] [${application}] ${pid} ${level}| ${JSON.stringify(
-    hello,
-  )}\n`;
+  return `[${time}] [${host}] [${application}] ${pid} ${level}| ${JSON.stringify(hello)}\n`;
 }
 
 const hydratedNoConNoColor: ExpectedOgmaOutput = {
@@ -190,9 +176,7 @@ const hydratedNoConNoColor: ExpectedOgmaOutput = {
 };
 
 function hydrateNoAppNoColorFactory(level: string): string {
-  return `[${time}] [${host}] ${pid} [${context}] ${level}| ${JSON.stringify(
-    hello,
-  )}\n`;
+  return `[${time}] [${host}] ${pid} [${context}] ${level}| ${JSON.stringify(hello)}\n`;
 }
 
 const hydratedNoAppNoColor: ExpectedOgmaOutput = {
@@ -289,9 +273,7 @@ const fullString: OgmaLogSet = {
 };
 
 function hydrateNoAppNoConStringFactory(level: string): string {
-  return `[${time}] ${color.magenta(
-    '[' + host + ']',
-  )} ${pid} ${level}| ${message}\n`;
+  return `[${time}] ${color.magenta('[' + host + ']')} ${pid} ${level}| ${message}\n`;
 }
 
 const hydratedNoAppNoConString: ExpectedOgmaOutput = {

--- a/packages/logger/test/command.spec.ts
+++ b/packages/logger/test/command.spec.ts
@@ -1,11 +1,5 @@
 import { createWriteStream, promises } from 'fs';
-import {
-  ExpectedOgmaOutput,
-  jsonLogs,
-  logKeys,
-  OgmaLogSet,
-  stringLogs,
-} from './command.fixtures';
+import { ExpectedOgmaOutput, jsonLogs, logKeys, OgmaLogSet, stringLogs } from './command.fixtures';
 import { ogmaHydrate } from '../src/command/command';
 import * as messages from '../src/command/messages';
 import { OgmaLog } from '../src/interfaces/ogma-log';
@@ -25,23 +19,17 @@ const dest = createWriteStream('/dev/null');
 
 const levelShouldPass = () => 'Level %s should pass';
 
-const writeSpy = jest
-  .spyOn(process.stdout, 'write')
-  .mockImplementation((message: any) => {
-    dest.write(message);
-    return true;
-  });
+const writeSpy = jest.spyOn(process.stdout, 'write').mockImplementation((message: any) => {
+  dest.write(message);
+  return true;
+});
 
-const errorSpy = jest
-  .spyOn(process.stderr, 'write')
-  .mockImplementation((message: any) => {
-    dest.write(message);
-    return true;
-  });
+const errorSpy = jest.spyOn(process.stderr, 'write').mockImplementation((message: any) => {
+  dest.write(message);
+  return true;
+});
 
-const exitSpy = jest
-  .spyOn(process, 'exit')
-  .mockImplementation(() => '' as never);
+const exitSpy = jest.spyOn(process, 'exit').mockImplementation(() => '' as never);
 
 const spyOnRead = (fileContents: OgmaLog): jest.SpyInstance => {
   return jest
@@ -62,10 +50,7 @@ const someFile = 'someFile';
 
 const hydrateArgs = ['node', '/dev/null', someFile];
 
-const ogmaHydrateTest = async (
-  readVal: OgmaLog,
-  expectedVal: string,
-): Promise<void> => {
+const ogmaHydrateTest = async (readVal: OgmaLog, expectedVal: string): Promise<void> => {
   expect.assertions(4);
   const readSpy = spyOnRead(readVal);
   await expect(ogmaHydrate(hydrateArgs)).resolves.not.toThrow();
@@ -102,33 +87,22 @@ describe.each([
   [true, stringLogs.noConString, stringLogs.hydratedNoConString],
   [true, stringLogs.noAppString, stringLogs.hydratedNoAppString],
   [true, stringLogs.fullString, stringLogs.hydratedFullString],
-  [
-    false,
-    stringLogs.noAppNoConString,
-    stringLogs.hydratedNoAppNoConNoColorString,
-  ],
+  [false, stringLogs.noAppNoConString, stringLogs.hydratedNoAppNoConNoColorString],
   [false, stringLogs.noConString, stringLogs.hydratedNoConNoColorString],
   [false, stringLogs.noAppString, stringLogs.hydratedNoAppNoColorString],
   [false, stringLogs.fullString, stringLogs.hydratedFullNoColorString],
-])(
-  'Hydrate TTY %s index %#',
-  (tty: boolean, logSet: OgmaLogSet, output: ExpectedOgmaOutput) => {
-    beforeEach(() => setTTY(tty));
-    afterEach(() => resetWrite());
-    it.each(logKeys)(levelShouldPass(), async (key: string) => {
-      await ogmaHydrateTest(logSet[key], output[key]);
-    });
-  },
-);
+])('Hydrate TTY %s index %#', (tty: boolean, logSet: OgmaLogSet, output: ExpectedOgmaOutput) => {
+  beforeEach(() => setTTY(tty));
+  afterEach(() => resetWrite());
+  it.each(logKeys)(levelShouldPass(), async (key: string) => {
+    await ogmaHydrateTest(logSet[key], output[key]);
+  });
+});
 
 describe('command line flags', () => {
   afterEach(() => resetWrite());
   it('should set --color to true', async () => {
-    await ogmaHydrateTestWithFlags(
-      jsonLogs.fullJSON.info,
-      jsonLogs.hydratedFull.info,
-      '--color',
-    );
+    await ogmaHydrateTestWithFlags(jsonLogs.fullJSON.info, jsonLogs.hydratedFull.info, '--color');
   });
   it('should set --color=true to true', async () => {
     await ogmaHydrateTestWithFlags(

--- a/packages/nestjs-module/src/decorators/ogma-context.decorator.ts
+++ b/packages/nestjs-module/src/decorators/ogma-context.decorator.ts
@@ -1,11 +1,6 @@
 import { Inject } from '@nestjs/common';
-import {
-  OGMA_CONTEXT,
-  OGMA_INSTANCE,
-  OGMA_INTERCEPTOR_OPTIONS,
-} from '../ogma.constants';
+import { OGMA_CONTEXT, OGMA_INSTANCE, OGMA_INTERCEPTOR_OPTIONS } from '../ogma.constants';
 
 export const InjectOgma = () => Inject(OGMA_INSTANCE);
 export const InjectOgmaContext = () => Inject(OGMA_CONTEXT);
-export const InjectOgmaInterceptorOptions = () =>
-  Inject(OGMA_INTERCEPTOR_OPTIONS);
+export const InjectOgmaInterceptorOptions = () => Inject(OGMA_INTERCEPTOR_OPTIONS);

--- a/packages/nestjs-module/src/decorators/ogma-logger.decorator.ts
+++ b/packages/nestjs-module/src/decorators/ogma-logger.decorator.ts
@@ -1,18 +1,9 @@
 import { Inject } from '@nestjs/common';
-import {
-  createProviderToken,
-  createRequestScopedProviderToken,
-} from '../ogma.provider';
+import { createProviderToken, createRequestScopedProviderToken } from '../ogma.provider';
 import { Type } from '../interfaces';
 
 export const OgmaLogger = (topic: string | (() => any) | Type<any>) =>
   Inject(createProviderToken(typeof topic === 'function' ? topic.name : topic));
 
-export const OgmaLoggerRequestScoped = (
-  topic: string | (() => any) | Type<any>,
-) =>
-  Inject(
-    createRequestScopedProviderToken(
-      typeof topic === 'function' ? topic.name : topic,
-    ),
-  );
+export const OgmaLoggerRequestScoped = (topic: string | (() => any) | Type<any>) =>
+  Inject(createRequestScopedProviderToken(typeof topic === 'function' ? topic.name : topic));

--- a/packages/nestjs-module/src/decorators/skip.decorator.ts
+++ b/packages/nestjs-module/src/decorators/skip.decorator.ts
@@ -1,11 +1,7 @@
 import { OGMA_INTERCEPTOR_SKIP } from '../ogma.constants';
 
 export function OgmaSkip() {
-  return (
-    target: any,
-    key?: string | symbol,
-    descriptor?: TypedPropertyDescriptor<any>,
-  ) => {
+  return (target: any, key?: string | symbol, descriptor?: TypedPropertyDescriptor<any>) => {
     if (descriptor) {
       Reflect.defineMetadata(OGMA_INTERCEPTOR_SKIP, true, descriptor.value);
       return descriptor;

--- a/packages/nestjs-module/src/interceptor/interfaces/interceptor-service.interface.ts
+++ b/packages/nestjs-module/src/interceptor/interfaces/interceptor-service.interface.ts
@@ -2,6 +2,13 @@ import { ExecutionContext, HttpException } from '@nestjs/common';
 import { OgmaInterceptorServiceOptions } from '../../interfaces/ogma-options.interface';
 import { LogObject } from './log.interface';
 
+export interface InterceptorMeta {
+  context: ExecutionContext;
+  startTime: number;
+  options: OgmaInterceptorServiceOptions;
+  correlationId: string;
+}
+
 export interface InterceptorService {
   getSuccessContext(
     data: number,

--- a/packages/nestjs-module/src/interceptor/providers/abstract-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/abstract-interceptor.service.ts
@@ -43,11 +43,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
     };
   }
 
-  getStatus(
-    context: ExecutionContext,
-    inColor: boolean,
-    error?: HttpException | Error,
-  ): string {
+  getStatus(context: ExecutionContext, inColor: boolean, error?: HttpException | Error): string {
     const status = error ? 500 : 200;
     return inColor ? this.wrapInColor(status) : status.toString();
   }
@@ -82,11 +78,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
     return statusString;
   }
 
-  protected isBetween(
-    comparator: number,
-    bottom: number,
-    top: number,
-  ): boolean {
+  protected isBetween(comparator: number, bottom: number, top: number): boolean {
     return comparator >= bottom && comparator < top;
   }
 }

--- a/packages/nestjs-module/src/interceptor/providers/delegator.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/delegator.service.ts
@@ -97,10 +97,7 @@ export class DelegatorService {
     return this[parser][method](data, context, startTime, options);
   }
 
-  private getStringOrObject(
-    data: LogObject,
-    options: { json: boolean },
-  ): string | LogObject {
+  private getStringOrObject(data: LogObject, options: { json: boolean }): string | LogObject {
     return options.json
       ? data
       : `${data.callerAddress} - ${data.method} ${data.callPoint} ${data.protocol} ${data.status} ${data.responseTime}ms - ${data.contentLength}`;

--- a/packages/nestjs-module/src/interceptor/providers/http-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/http-interceptor.service.ts
@@ -4,18 +4,11 @@ import { AbstractInterceptorService } from './abstract-interceptor.service';
 
 @Injectable()
 export abstract class HttpInterceptorService extends AbstractInterceptorService {
-  getStatus(
-    context: ExecutionContext,
-    inColor: boolean,
-    error?: HttpException | Error,
-  ): string {
+  getStatus(context: ExecutionContext, inColor: boolean, error?: HttpException | Error): string {
     let status: number;
     const res = this.getResponse(context);
     status = res.statusCode;
-    const reflectStatus = this.reflector.get<number>(
-      HTTP_CODE_METADATA,
-      context.getHandler(),
-    );
+    const reflectStatus = this.reflector.get<number>(HTTP_CODE_METADATA, context.getHandler());
     status = reflectStatus || status;
     if (error) {
       status = this.determineStatusCodeFromError(error);

--- a/packages/nestjs-module/src/interfaces/index.ts
+++ b/packages/nestjs-module/src/interfaces/index.ts
@@ -1,1 +1,2 @@
 export * from './ogma-options.interface';
+export * from './ogma-service-meta.interface';

--- a/packages/nestjs-module/src/interfaces/ogma-service-meta.interface.ts
+++ b/packages/nestjs-module/src/interfaces/ogma-service-meta.interface.ts
@@ -1,0 +1,5 @@
+export interface OgmaServiceMeta {
+  context?: string;
+  correlationId?: string;
+  [key: string]: unknown;
+}

--- a/packages/nestjs-module/src/ogma-core.module.ts
+++ b/packages/nestjs-module/src/ogma-core.module.ts
@@ -1,5 +1,5 @@
 import { createConfigurableDynamicRootModule } from '@golevelup/nestjs-modules';
-import { Module } from '@nestjs/common';
+import { Global, Module } from '@nestjs/common';
 import {
   DelegatorService,
   GqlInterceptorService,
@@ -24,6 +24,7 @@ import {
 } from './ogma.provider';
 import { OgmaService } from './ogma.service';
 
+@Global()
 @Module({})
 export class OgmaCoreModule extends createConfigurableDynamicRootModule<
   OgmaCoreModule,
@@ -78,6 +79,4 @@ export class OgmaCoreModule extends createConfigurableDynamicRootModule<
     RpcInterceptorService,
     WebsocketInterceptorService,
   ],
-}) {
-  // static Deferred = OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0);
-}
+}) {}

--- a/packages/nestjs-module/src/ogma.module.ts
+++ b/packages/nestjs-module/src/ogma.module.ts
@@ -1,25 +1,17 @@
 import { AsyncModuleConfig } from '@golevelup/nestjs-modules';
 import { DynamicModule, Module, Provider } from '@nestjs/common';
 import { OgmaModuleOptions, Type } from './interfaces';
-import {
-  createLoggerProviders,
-  createRequestScopedLoggerProviders,
-} from './ogma.provider';
+import { createLoggerProviders, createRequestScopedLoggerProviders } from './ogma.provider';
 import { OgmaCoreModule } from './ogma-core.module';
 import { OgmaProviderOptions } from './interfaces/ogma-provieder-options.interface';
 
-@Module({
-  /* imports: [OgmaCoreModule.Deferred],
-  exports: [OgmaCoreModule], */
-})
+@Module({})
 export class OgmaModule {
   static forRoot(options: OgmaModuleOptions): DynamicModule {
     return OgmaCoreModule.forRoot(OgmaCoreModule, options);
   }
 
-  static forRootAsync(
-    options: AsyncModuleConfig<OgmaModuleOptions>,
-  ): DynamicModule {
+  static forRootAsync(options: AsyncModuleConfig<OgmaModuleOptions>): DynamicModule {
     return OgmaCoreModule.forRootAsync(OgmaCoreModule, options);
   }
 
@@ -37,7 +29,7 @@ export class OgmaModule {
   ): DynamicModule {
     const providers: Provider[] = this.createProviders(context, options);
     return {
-      imports: [OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0)],
+      imports: [OgmaCoreModule],
       module: OgmaModule,
       providers,
       exports: providers,
@@ -63,7 +55,7 @@ export class OgmaModule {
     });
     return {
       module: OgmaModule,
-      imports: [OgmaCoreModule.externallyConfigured(OgmaCoreModule, 0)],
+      imports: [OgmaCoreModule],
       providers,
       exports: providers,
     };

--- a/packages/nestjs-module/src/ogma.provider.ts
+++ b/packages/nestjs-module/src/ogma.provider.ts
@@ -9,12 +9,7 @@ import {
 } from './ogma.constants';
 import { OgmaService } from './ogma.service';
 import { AbstractInterceptorService } from './interceptor/providers';
-import {
-  OgmaInterceptorOptions,
-  OgmaModuleOptions,
-  OgmaServiceOptions,
-  Type,
-} from './interfaces';
+import { OgmaInterceptorOptions, OgmaModuleOptions, OgmaServiceOptions, Type } from './interfaces';
 import { RequestContext } from './interfaces/request-context.interface';
 
 /**
@@ -27,9 +22,7 @@ export function createOgmaProvider(options?: Partial<OgmaOptions>): Ogma {
   });
 }
 
-function mergeInterceptorDefaults(
-  options: OgmaInterceptorOptions,
-): OgmaInterceptorOptions {
+function mergeInterceptorDefaults(options: OgmaInterceptorOptions): OgmaInterceptorOptions {
   const mergedOptions: OgmaInterceptorOptions = {
     ...{ http: false, ws: false, rpc: false, gql: false },
     ...options,
@@ -50,9 +43,7 @@ export function createOgmaInterceptorOptionsFactory(
   return mergeInterceptorDefaults(intOpts);
 }
 
-export function createOgmaServiceOptions(
-  options: OgmaModuleOptions,
-): OgmaServiceOptions {
+export function createOgmaServiceOptions(options: OgmaModuleOptions): OgmaServiceOptions {
   return options.service;
 }
 
@@ -64,9 +55,7 @@ export function createRequestScopedProviderToken(topic: string): string {
   return OGMA_REQUEST_SCOPED_SERVICE_TOKEN + ':' + topic;
 }
 
-export function createLoggerProviders(
-  topic: string | (() => any) | Type<any>,
-): Provider[] {
+export function createLoggerProviders(topic: string | (() => any) | Type<any>): Provider[] {
   topic = typeof topic === 'function' ? topic.name : topic;
   const token = createProviderToken(topic);
   return [
@@ -90,10 +79,7 @@ export function createRequestScopedLoggerProviders(
       inject: [OGMA_INSTANCE, CONTEXT],
       provide: token,
       scope: Scope.REQUEST,
-      useFactory: (
-        ogmaInstance: Ogma,
-        requestContext: RequestContext,
-      ): OgmaService => {
+      useFactory: (ogmaInstance: Ogma, requestContext: RequestContext): OgmaService => {
         return new OgmaService(ogmaInstance, topic as string, requestContext);
       },
     },
@@ -103,10 +89,7 @@ export function createRequestScopedLoggerProviders(
 export const interceptorProviderFactory = (
   type: 'http' | 'gql' | 'ws' | 'rpc',
   backupClass: Type<AbstractInterceptorService>,
-): ((
-  opt: OgmaInterceptorOptions,
-  reflector: Reflector,
-) => Type<AbstractInterceptorService>) => (
+): ((opt: OgmaInterceptorOptions, reflector: Reflector) => Type<AbstractInterceptorService>) => (
   intOpts: OgmaInterceptorOptions,
   reflector: Reflector,
 ): Type<AbstractInterceptorService> =>

--- a/packages/nestjs-module/src/ogma.service.ts
+++ b/packages/nestjs-module/src/ogma.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, LoggerService, Optional } from '@nestjs/common';
+import { Injectable, Optional } from '@nestjs/common';
 import { Ogma } from '@ogma/logger';
 import { InjectOgma, InjectOgmaContext } from './decorators';
+import { OgmaServiceMeta } from './interfaces';
 import { RequestContext } from './interfaces/request-context.interface';
 
 @Injectable()
-export class OgmaService implements LoggerService {
+export class OgmaService {
   private readonly context?: string;
   private readonly ogma: Ogma;
 
@@ -31,9 +32,7 @@ export class OgmaService implements LoggerService {
     this.ogma = ogma ?? new Ogma();
   }
 
-  private getRequestId(
-    requestContext: RequestContext | Record<string, any>,
-  ): string | undefined {
+  private getRequestId(requestContext: RequestContext | Record<string, any>): string | undefined {
     if (typeof requestContext.getContext !== 'undefined') {
       return requestContext.getContext().requestId;
     }
@@ -46,8 +45,8 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public info(message: any, context?: string, requestId?: string): void {
-    this.printMessage(message, 'info', context, requestId);
+  public info(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'info', meta);
   }
 
   /**
@@ -55,8 +54,8 @@ export class OgmaService implements LoggerService {
    * @param message What to print to the Ogma instance
    * @param context Optional context if you want to change what the original context was
    */
-  public error(message: any, context?: string): void {
-    this.printMessage(message, 'error', context);
+  public error(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'error', meta);
   }
 
   /**
@@ -65,8 +64,8 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public warn(message: any, context?: string, requestId?: string): void {
-    this.printMessage(message, 'warn', context, requestId);
+  public warn(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'warn', meta);
   }
 
   /**
@@ -75,8 +74,8 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public debug(message: any, context?: string, requestId?: string): void {
-    this.printMessage(message, 'debug', context, requestId);
+  public debug(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'debug', meta);
   }
 
   /**
@@ -85,8 +84,8 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public fatal(message: any, context?: string, requestId?: string): void {
-    this.printMessage(message, 'fatal', context, requestId);
+  public fatal(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'fatal', meta);
   }
 
   /**
@@ -95,8 +94,8 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public silly(message: any, context?: string, requestId?: string): void {
-    this.printMessage(message, 'silly', context, requestId);
+  public silly(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'silly', meta);
   }
 
   /**
@@ -105,8 +104,8 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public verbose(message: any, context?: string, requestId?: string): void {
-    this.printMessage(message, 'verbose', context, requestId);
+  public verbose(message: any, meta?: OgmaServiceMeta): void {
+    this.printMessage(message, 'verbose', meta);
   }
 
   /**
@@ -115,25 +114,24 @@ export class OgmaService implements LoggerService {
    * @param context Optional context if you want to change what the original context was
    * @param requestId Optional id of an request
    */
-  public printError(error: Error, context?: string, requestId?: string): void {
-    this.printMessage('', 'error', context, requestId);
-    if (!requestId && this.requestContext && this.context) {
-      requestId = this.getRequestId(this.requestContext);
+  public printError(error: Error, meta: OgmaServiceMeta = {}): void {
+    this.printMessage('', 'error', meta);
+    if (!meta.correlationId && this.requestContext && this.context) {
+      meta.correlationId = this.getRequestId(this.requestContext);
     }
-    context = context ?? this.context;
-    this.ogma.printError(error, context, undefined, requestId);
+    meta.context = meta.context ?? this.context;
+    this.ogma.printError(error, meta);
   }
 
   private printMessage(
     message: any,
     levelString: Exclude<keyof Ogma, 'printMessage' | 'printError'>,
-    context?: string,
-    requestId?: string,
+    meta: OgmaServiceMeta = {},
   ): void {
-    context = context ?? this.context;
-    if (!requestId && this.requestContext && this.context) {
-      requestId = this.getRequestId(this.requestContext);
+    meta.context = meta.context ?? this.context;
+    if (!meta.correlationId && this.requestContext && this.context) {
+      meta.correlationId = this.getRequestId(this.requestContext);
     }
-    this.ogma[levelString](message, context, undefined, requestId);
+    this.ogma[levelString](message, meta);
   }
 }

--- a/packages/nestjs-module/test/abstract-interceptor.service.spec.ts
+++ b/packages/nestjs-module/test/abstract-interceptor.service.spec.ts
@@ -5,11 +5,7 @@ import { color } from '@ogma/logger';
 import { AbstractInterceptorService } from '../src/interceptor/providers/abstract-interceptor.service';
 
 class TestParser extends AbstractInterceptorService {
-  getStatus(
-    context: ExecutionContext,
-    inColor: boolean,
-    error?: Error | HttpException,
-  ): string {
+  getStatus(context: ExecutionContext, inColor: boolean, error?: Error | HttpException): string {
     const status = error ? 500 : 200;
     return inColor ? this.wrapInColor(status) : status.toString();
   }

--- a/packages/nestjs-module/test/delegator.service.spec.ts
+++ b/packages/nestjs-module/test/delegator.service.spec.ts
@@ -12,13 +12,11 @@ import {
   WebsocketInterceptorService,
 } from '../src/interceptor/providers';
 
-const logProperly = (type: 'http' | 'gql' | 'ws' | 'rpc') =>
-  `should log properly for ${type}`;
+const logProperly = (type: 'http' | 'gql' | 'ws' | 'rpc') => `should log properly for ${type}`;
 const setRequestIdProperly = (type: 'http' | 'gql' | 'ws' | 'rpc') =>
   `should set request id properly for ${type}`;
 
-const abstractInterceptorServiceMock = () =>
-  createMock<AbstractInterceptorService>();
+const abstractInterceptorServiceMock = () => createMock<AbstractInterceptorService>();
 
 const spyFactory = (
   parser: AbstractInterceptorService,
@@ -85,15 +83,11 @@ describe('DelegatorService', () => {
   describe('getContextSuccessString', () => {
     const data = 'someData';
     it(logProperly('http'), () => {
-      const ctxMock = createMock<ExecutionContext>(
-        httpContext as Partial<ExecutionContext>,
+      const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
+      const spy = spyFactory(http, 'getSuccessContext').mockReturnValueOnce(parserReturn);
+      expect(delegate.getContextSuccessString(data, ctxMock, startTime, options)).toBe(
+        parsedString,
       );
-      const spy = spyFactory(http, 'getSuccessContext').mockReturnValueOnce(
-        parserReturn,
-      );
-      expect(
-        delegate.getContextSuccessString(data, ctxMock, startTime, options),
-      ).toBe(parsedString);
       expect(spy).toBeCalledWith(
         Buffer.from(JSON.stringify(data)).byteLength,
         ctxMock,
@@ -105,12 +99,10 @@ describe('DelegatorService', () => {
       const ctxMock = createMock<ExecutionContext>({
         getType: () => 'graphql',
       });
-      const spy = spyFactory(gql, 'getSuccessContext').mockReturnValueOnce(
-        parserReturn,
+      const spy = spyFactory(gql, 'getSuccessContext').mockReturnValueOnce(parserReturn);
+      expect(delegate.getContextSuccessString(data, ctxMock, startTime, options)).toBe(
+        parsedString,
       );
-      expect(
-        delegate.getContextSuccessString(data, ctxMock, startTime, options),
-      ).toBe(parsedString);
       expect(spy).toBeCalledWith(
         Buffer.from(JSON.stringify(data)).byteLength,
         ctxMock,
@@ -122,12 +114,10 @@ describe('DelegatorService', () => {
       const ctxMock = createMock<ExecutionContext>({
         getType: () => 'ws',
       });
-      const spy = spyFactory(ws, 'getSuccessContext').mockReturnValueOnce(
-        parserReturn,
+      const spy = spyFactory(ws, 'getSuccessContext').mockReturnValueOnce(parserReturn);
+      expect(delegate.getContextSuccessString(data, ctxMock, startTime, options)).toBe(
+        parsedString,
       );
-      expect(
-        delegate.getContextSuccessString(data, ctxMock, startTime, options),
-      ).toBe(parsedString);
       expect(spy).toBeCalledWith(
         Buffer.from(JSON.stringify(data)).byteLength,
         ctxMock,
@@ -139,12 +129,10 @@ describe('DelegatorService', () => {
       const ctxMock = createMock<ExecutionContext>({
         getType: () => 'rpc',
       });
-      const spy = spyFactory(rpc, 'getSuccessContext').mockReturnValueOnce(
-        parserReturn,
+      const spy = spyFactory(rpc, 'getSuccessContext').mockReturnValueOnce(parserReturn);
+      expect(delegate.getContextSuccessString(data, ctxMock, startTime, options)).toBe(
+        parsedString,
       );
-      expect(
-        delegate.getContextSuccessString(data, ctxMock, startTime, options),
-      ).toBe(parsedString);
       expect(spy).toBeCalledWith(
         Buffer.from(JSON.stringify(data)).byteLength,
         ctxMock,
@@ -156,51 +144,33 @@ describe('DelegatorService', () => {
   describe('getContextErrorString', () => {
     const error = new Error('Big oof');
     it(logProperly('http'), () => {
-      const spy = spyFactory(http, 'getErrorContext').mockReturnValueOnce(
-        parserReturn,
-      );
-      const ctxMock = createMock<ExecutionContext>(
-        httpContext as Partial<ExecutionContext>,
-      );
-      expect(
-        delegate.getContextErrorString(error, ctxMock, startTime, options),
-      ).toBe(parsedString);
+      const spy = spyFactory(http, 'getErrorContext').mockReturnValueOnce(parserReturn);
+      const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
+      expect(delegate.getContextErrorString(error, ctxMock, startTime, options)).toBe(parsedString);
       expect(spy).toBeCalledWith(error, ctxMock, startTime, options);
     });
     it(logProperly('gql'), () => {
-      const spy = spyFactory(gql, 'getErrorContext').mockReturnValueOnce(
-        parserReturn,
-      );
+      const spy = spyFactory(gql, 'getErrorContext').mockReturnValueOnce(parserReturn);
       const ctxMock = createMock<ExecutionContext>({
         getType: () => 'graphql',
       });
-      expect(
-        delegate.getContextErrorString(error, ctxMock, startTime, options),
-      ).toBe(parsedString);
+      expect(delegate.getContextErrorString(error, ctxMock, startTime, options)).toBe(parsedString);
       expect(spy).toBeCalledWith(error, ctxMock, startTime, options);
     });
     it(logProperly('ws'), () => {
-      const spy = spyFactory(ws, 'getErrorContext').mockReturnValueOnce(
-        parserReturn,
-      );
+      const spy = spyFactory(ws, 'getErrorContext').mockReturnValueOnce(parserReturn);
       const ctxMock = createMock<ExecutionContext>({
         getType: () => 'ws',
       });
-      expect(
-        delegate.getContextErrorString(error, ctxMock, startTime, options),
-      ).toBe(parsedString);
+      expect(delegate.getContextErrorString(error, ctxMock, startTime, options)).toBe(parsedString);
       expect(spy).toBeCalledWith(error, ctxMock, startTime, options);
     });
     it(logProperly('rpc'), () => {
-      const spy = spyFactory(rpc, 'getErrorContext').mockReturnValueOnce(
-        parserReturn,
-      );
+      const spy = spyFactory(rpc, 'getErrorContext').mockReturnValueOnce(parserReturn);
       const ctxMock = createMock<ExecutionContext>({
         getType: () => 'rpc',
       });
-      expect(
-        delegate.getContextErrorString(error, ctxMock, startTime, options),
-      ).toBe(parsedString);
+      expect(delegate.getContextErrorString(error, ctxMock, startTime, options)).toBe(parsedString);
       expect(spy).toBeCalledWith(error, ctxMock, startTime, options);
     });
   });
@@ -216,9 +186,7 @@ describe('DelegatorService', () => {
     });
     it(setRequestIdProperly('http'), () => {
       const spy = spyFactory(http, 'setRequestId');
-      const ctxMock = createMock<ExecutionContext>(
-        httpContext as Partial<ExecutionContext>,
-      );
+      const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
       delegate.setRequestId(ctxMock, requestId);
       expect(spy).toBeCalledWith(ctxMock, requestId);
     });
@@ -241,12 +209,8 @@ describe('DelegatorService', () => {
   });
   describe('useJsonFormat', () => {
     it('should return as JSON instead of string', () => {
-      const spy = spyFactory(http, 'getSuccessContext').mockReturnValueOnce(
-        parserReturn,
-      );
-      const ctxMock = createMock<ExecutionContext>(
-        httpContext as Partial<ExecutionContext>,
-      );
+      const spy = spyFactory(http, 'getSuccessContext').mockReturnValueOnce(parserReturn);
+      const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
       expect(
         delegate.getContextSuccessString('data', ctxMock, startTime, {
           json: true,
@@ -275,12 +239,10 @@ describe('DelegatorService', () => {
         protocol: 'HTTP/1.1',
         status: '200',
       });
-      const ctxMock = createMock<ExecutionContext>(
-        httpContext as Partial<ExecutionContext>,
+      const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
+      expect(delegate.getContextSuccessString(null, ctxMock, startTime, options)).toBe(
+        '127.0.0.1 - GET / HTTP/1.1 200 2ms - 0',
       );
-      expect(
-        delegate.getContextSuccessString(null, ctxMock, startTime, options),
-      ).toBe('127.0.0.1 - GET / HTTP/1.1 200 2ms - 0');
       expect(spy).toBeCalledWith(0, ctxMock, startTime, options);
     });
   });

--- a/packages/nestjs-module/test/ogma-context.decorator.spec.ts
+++ b/packages/nestjs-module/test/ogma-context.decorator.spec.ts
@@ -1,8 +1,4 @@
-import {
-  InjectOgma,
-  InjectOgmaContext,
-  InjectOgmaInterceptorOptions,
-} from '../src';
+import { InjectOgma, InjectOgmaContext, InjectOgmaInterceptorOptions } from '../src';
 
 const func = expect.any(Function);
 

--- a/packages/nestjs-module/test/ogma.interceptor.spec.ts
+++ b/packages/nestjs-module/test/ogma.interceptor.spec.ts
@@ -10,10 +10,7 @@ import { OGMA_INTERCEPTOR_OPTIONS } from '../src/ogma.constants';
 const shouldSkipFor = (type: 'http' | 'ws' | 'gql' | 'rpc'): string =>
   `should skip for no ${type} parser`;
 
-const nullifyOption = (
-  type: 'http' | 'ws' | 'gql' | 'rpc',
-  interceptor: OgmaInterceptor,
-): void => {
+const nullifyOption = (type: 'http' | 'ws' | 'gql' | 'rpc', interceptor: OgmaInterceptor): void => {
   (interceptor as any).options[type] = false;
 };
 
@@ -91,9 +88,7 @@ describe('OgmaInterceptor', () => {
         delegateSpy.mockClear();
       });
       it('should log data', (done) => {
-        const ctxMock = createMock<ExecutionContext>(
-          httpContext as Partial<ExecutionContext>,
-        );
+        const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
         interceptor.intercept(ctxMock, callHandler).subscribe({
           next: () => {
             return;
@@ -114,20 +109,18 @@ describe('OgmaInterceptor', () => {
       it('should not log data', (done) => {
         jest.spyOn(reflector, 'get').mockReturnValueOnce(true);
 
-        interceptor
-          .intercept(createMock<ExecutionContext>(), callHandler)
-          .subscribe({
-            next: () => {
-              return;
-            },
-            error: () => {
-              throw new Error('Logging Error in data');
-            },
-            complete: () => {
-              expect(delegateSpy).toBeCalledTimes(0);
-              done();
-            },
-          });
+        interceptor.intercept(createMock<ExecutionContext>(), callHandler).subscribe({
+          next: () => {
+            return;
+          },
+          error: () => {
+            throw new Error('Logging Error in data');
+          },
+          complete: () => {
+            expect(delegateSpy).toBeCalledTimes(0);
+            done();
+          },
+        });
       });
     });
     describe('log error', () => {
@@ -140,37 +133,32 @@ describe('OgmaInterceptor', () => {
         delegateSpy.mockClear();
       });
       it('should log error', (done) => {
-        const ctxMock = createMock<ExecutionContext>(
-          httpContext as Partial<ExecutionContext>,
-        );
+        const ctxMock = createMock<ExecutionContext>(httpContext as Partial<ExecutionContext>);
         interceptor.intercept(ctxMock, callHandler).subscribe({
           next: () => {
             throw new Error('Logging data in error');
           },
           error: () => {
-            expect(delegateSpy).toBeCalledWith(
-              new Error('Big oof'),
-              ctxMock,
-              0,
-              { json: false, color: false, http: true },
-            );
+            expect(delegateSpy).toBeCalledWith(new Error('Big oof'), ctxMock, 0, {
+              json: false,
+              color: false,
+              http: true,
+            });
             done();
           },
         });
       });
       it('should not log error', (done) => {
         jest.spyOn(reflector, 'get').mockReturnValueOnce(true);
-        interceptor
-          .intercept(createMock<ExecutionContext>(), callHandler)
-          .subscribe({
-            next: () => {
-              throw new Error('Logging data in error');
-            },
-            error: () => {
-              expect(delegateSpy).toBeCalledTimes(0);
-              done();
-            },
-          });
+        interceptor.intercept(createMock<ExecutionContext>(), callHandler).subscribe({
+          next: () => {
+            throw new Error('Logging data in error');
+          },
+          error: () => {
+            expect(delegateSpy).toBeCalledTimes(0);
+            done();
+          },
+        });
       });
     });
   });
@@ -239,11 +227,10 @@ describe('OgmaInterceptor', () => {
         }),
       });
       interceptor.log('logValue', ctxMock, '1598961763272766');
-      expect(logSpy).toBeCalledWith(
-        'logValue',
-        'className#methodName',
-        '1598961763272766',
-      );
+      expect(logSpy).toBeCalledWith('logValue', {
+        context: 'className#methodName',
+        correlationId: '1598961763272766',
+      });
     });
   });
 });

--- a/packages/nestjs-module/test/ogma.provider.spec.ts
+++ b/packages/nestjs-module/test/ogma.provider.spec.ts
@@ -34,9 +34,7 @@ describe('createOgmaProvider', () => {
 });
 describe('createOgmaInterceptorOptionsFactory', () => {
   it('should return false', () => {
-    expect(
-      createOgmaInterceptorOptionsFactory({ interceptor: false }),
-    ).toBeFalsy();
+    expect(createOgmaInterceptorOptionsFactory({ interceptor: false })).toBeFalsy();
   });
   it('should return the merged options', () => {
     expect(
@@ -94,9 +92,9 @@ describe('createLoggerProviders', () => {
   });
   it('should create a provider with a string for token', () => {
     const factory = expect.any(Function);
-    const providers: Provider<
-      FactoryProvider<OgmaService>
-    >[] = createLoggerProviders('TestService');
+    const providers: Provider<FactoryProvider<OgmaService>>[] = createLoggerProviders(
+      'TestService',
+    );
     expect(providers).toMatchObject([
       {
         inject: [OGMA_INSTANCE],
@@ -105,9 +103,7 @@ describe('createLoggerProviders', () => {
       },
     ]);
     const prov = providers[0];
-    expect((prov as any).useFactory(new Ogma()) instanceof OgmaService).toBe(
-      true,
-    );
+    expect((prov as any).useFactory(new Ogma()) instanceof OgmaService).toBe(true);
   });
 });
 describe('createRequestScopedLoggerProviders', () => {
@@ -124,9 +120,9 @@ describe('createRequestScopedLoggerProviders', () => {
   });
   it('should create a provider with a string for token', () => {
     const factory = expect.any(Function);
-    const providers: Provider<
-      FactoryProvider<OgmaService>
-    >[] = createRequestScopedLoggerProviders('TestService');
+    const providers: Provider<FactoryProvider<OgmaService>>[] = createRequestScopedLoggerProviders(
+      'TestService',
+    );
     expect(providers).toMatchObject([
       {
         inject: [OGMA_INSTANCE, CONTEXT],
@@ -136,9 +132,7 @@ describe('createRequestScopedLoggerProviders', () => {
       },
     ]);
     const prov = providers[0];
-    expect((prov as any).useFactory(new Ogma()) instanceof OgmaService).toBe(
-      true,
-    );
+    expect((prov as any).useFactory(new Ogma()) instanceof OgmaService).toBe(true);
   });
 });
 describe('interceptorProviderFactory', () => {

--- a/packages/nestjs-module/test/ogma.service.spec.ts
+++ b/packages/nestjs-module/test/ogma.service.spec.ts
@@ -62,21 +62,17 @@ describe('OgmaService', () => {
               it.each(['hello', 42, { key: 'value' }])(
                 'should call with value %o',
                 (value: any) => {
-                  service[level](value, customContext);
+                  service[level](value, { context: customContext });
                   expect(ogmaSpy).toBeCalledTimes(1);
                 },
               );
               it('should be able to call "callError"', () => {
                 const error = new Error('This is my error');
                 ogmaSpy = jest.spyOn(Ogma.prototype, 'printError');
-                service.printError(error, customContext);
+                service.printError(error, { context: customContext });
+                const foundContext = customContext ?? context ?? '';
                 expect(ogmaSpy).toBeCalledTimes(1);
-                expect(ogmaSpy).toBeCalledWith(
-                  error,
-                  customContext ?? context ?? '',
-                  undefined,
-                  undefined,
-                );
+                expect(ogmaSpy).toBeCalledWith(error, { context: foundContext });
               });
             });
           },
@@ -89,9 +85,7 @@ describe('OgmaService', () => {
 describe.each([new Ogma(), undefined])(
   'OgmaService with difference instances',
   (instance: Ogma | undefined) => {
-    it(`should still be defined with instance ${
-      instance ? 'new' : 'undefined'
-    }`, () => {
+    it(`should still be defined with instance ${instance ? 'new' : 'undefined'}`, () => {
       const service = new OgmaService(instance);
       expect(service).toHaveProperty('ogma');
       expect(service).toBeDefined();

--- a/packages/nestjs-module/test/skip.decorator.spec.ts
+++ b/packages/nestjs-module/test/skip.decorator.spec.ts
@@ -15,8 +15,6 @@ describe('OgmaSkip', () => {
       }
     }
     const testClass = new TestClass();
-    expect(
-      Reflect.getMetadata(OGMA_INTERCEPTOR_SKIP, testClass.shouldSkip),
-    ).toBe(true);
+    expect(Reflect.getMetadata(OGMA_INTERCEPTOR_SKIP, testClass.shouldSkip)).toBe(true);
   });
 });

--- a/packages/platform-express/test/express-interceptor.service.spec.ts
+++ b/packages/platform-express/test/express-interceptor.service.spec.ts
@@ -68,9 +68,7 @@ describe('ExpressParser', () => {
           }),
         }),
       });
-      expect(parser.getCallPoint(ctxMock)).toBe(
-        '/api/auth/callback?token=123abc',
-      );
+      expect(parser.getCallPoint(ctxMock)).toBe('/api/auth/callback?token=123abc');
     });
   });
 
@@ -83,9 +81,7 @@ describe('ExpressParser', () => {
     });
     it('should get the status from an exception (40x)', () => {
       const ctxMock = createMock<ExecutionContext>();
-      expect(parser.getStatus(ctxMock, false, new BadRequestException())).toBe(
-        '400',
-      );
+      expect(parser.getStatus(ctxMock, false, new BadRequestException())).toBe('400');
     });
     it('should get the status from an error(500)', () => {
       const ctxMock = createMock<ExecutionContext>();
@@ -100,10 +96,7 @@ describe('ExpressParser', () => {
         getHandler: () => sampleObject.func(),
       });
       expect(parser.getStatus(ctxMock, false)).toBe('201');
-      expect(reflector.get).toBeCalledWith(
-        HTTP_CODE_METADATA,
-        sampleObject.func(),
-      );
+      expect(reflector.get).toBeCalledWith(HTTP_CODE_METADATA, sampleObject.func());
     });
     it('should get the status in color', () => {
       const ctxMock = createMock<ExecutionContext>({

--- a/packages/platform-fastify/test/fastify-interceptor.service.spec.ts
+++ b/packages/platform-fastify/test/fastify-interceptor.service.spec.ts
@@ -70,9 +70,7 @@ describe('FastifyParser', () => {
           }),
         }),
       });
-      expect(parser.getCallPoint(ctxMock)).toBe(
-        '/api/auth/callback?token=123abc',
-      );
+      expect(parser.getCallPoint(ctxMock)).toBe('/api/auth/callback?token=123abc');
     });
   });
 
@@ -85,9 +83,7 @@ describe('FastifyParser', () => {
     });
     it('should get the status from an exception (40x)', () => {
       const ctxMock = createMock<ExecutionContext>();
-      expect(parser.getStatus(ctxMock, false, new BadRequestException())).toBe(
-        '400',
-      );
+      expect(parser.getStatus(ctxMock, false, new BadRequestException())).toBe('400');
     });
     it('should get the status from an error(500)', () => {
       const ctxMock = createMock<ExecutionContext>();
@@ -102,10 +98,7 @@ describe('FastifyParser', () => {
         getHandler: () => sampleObject.func(),
       });
       expect(parser.getStatus(ctxMock, false)).toBe('201');
-      expect(reflector.get).toBeCalledWith(
-        HTTP_CODE_METADATA,
-        sampleObject.func(),
-      );
+      expect(reflector.get).toBeCalledWith(HTTP_CODE_METADATA, sampleObject.func());
     });
     it('should get the status in color', () => {
       const ctxMock = createMock<ExecutionContext>({

--- a/packages/platform-graphql-fastify/test/graphql-fastify-interceptor.service.spec.ts
+++ b/packages/platform-graphql-fastify/test/graphql-fastify-interceptor.service.spec.ts
@@ -3,10 +3,7 @@ import { ExecutionContext } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { GraphQLFastifyParser } from '../src';
 
-const gqlMockFactory = (
-  context: Record<string, unknown>,
-  info: Record<string, unknown>,
-) =>
+const gqlMockFactory = (context: Record<string, unknown>, info: Record<string, unknown>) =>
   createMock<ExecutionContext>({
     getType: () => 'graphql',
     getHandler: () => 'query',

--- a/packages/platform-graphql/test/graphql-interceptor.service.spec.ts
+++ b/packages/platform-graphql/test/graphql-interceptor.service.spec.ts
@@ -4,10 +4,7 @@ import { Test } from '@nestjs/testing';
 import { Request, Response } from 'express';
 import { GraphQLParser } from '../src';
 
-const gqlMockFactory = (
-  context: Record<string, any>,
-  info: Record<string, any>,
-) =>
+const gqlMockFactory = (context: Record<string, any>, info: Record<string, any>) =>
   createMock<ExecutionContext>({
     getType: () => 'graphql',
     getHandler: () => 'query',
@@ -15,8 +12,7 @@ const gqlMockFactory = (
     getArgs: () => [{}, {}, context, info],
   });
 
-const gqlContextMockFactory = (contextMock: any) =>
-  gqlMockFactory(contextMock, {});
+const gqlContextMockFactory = (contextMock: any) => gqlMockFactory(contextMock, {});
 
 const gqlInfoMockFactory = (infoMock: any) => gqlMockFactory({}, infoMock);
 

--- a/packages/platform-grpc/test/grpc-interceptors.service.spec.ts
+++ b/packages/platform-grpc/test/grpc-interceptors.service.spec.ts
@@ -29,9 +29,7 @@ describe('GrpcParser', () => {
   describe('getCallPoint', () => {
     it('should return the reflected metadata pattern', () => {
       const funcMock = () => 'string';
-      const reflectSpy = jest
-        .spyOn(reflector, 'get')
-        .mockReturnValueOnce({ rpc: 'SayHello' });
+      const reflectSpy = jest.spyOn(reflector, 'get').mockReturnValueOnce({ rpc: 'SayHello' });
       const ctxMock = createMock<ExecutionContext>({
         getHandler: funcMock,
       });
@@ -67,19 +65,13 @@ describe('GrpcParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
   describe('getProtocol', () => {

--- a/packages/platform-kafka/test/kafka-interceptor.service.spec.ts
+++ b/packages/platform-kafka/test/kafka-interceptor.service.spec.ts
@@ -73,19 +73,13 @@ describe('KafkaParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
   describe('getProtocol', () => {

--- a/packages/platform-mqtt/test/mqtt-interceptor.service.spec.ts
+++ b/packages/platform-mqtt/test/mqtt-interceptor.service.spec.ts
@@ -41,9 +41,7 @@ describe('MQTTParser', () => {
         switchToRpc: () => ({
           getContext: () => ({
             getPacket: () => ({
-              payload: Buffer.from(
-                JSON.stringify({ data: { hello: 'world', ip: '127.0.0.1' } }),
-              ),
+              payload: Buffer.from(JSON.stringify({ data: { hello: 'world', ip: '127.0.0.1' } })),
             }),
           }),
         }),
@@ -55,9 +53,7 @@ describe('MQTTParser', () => {
         switchToRpc: () => ({
           getContext: () => ({
             getPacket: () => ({
-              payload: Buffer.from(
-                JSON.stringify({ data: { hello: 'world' } }),
-              ),
+              payload: Buffer.from(JSON.stringify({ data: { hello: 'world' } })),
             }),
           }),
         }),
@@ -84,19 +80,13 @@ describe('MQTTParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
   describe('getProtocol', () => {

--- a/packages/platform-nats/test/nats-interceptor.service.spec.ts
+++ b/packages/platform-nats/test/nats-interceptor.service.spec.ts
@@ -22,9 +22,7 @@ describe('NatsParser', () => {
           }),
         }),
       });
-      expect(parser.getCallPoint(ctxMock)).toBe(
-        JSON.stringify({ cmd: 'message' }),
-      );
+      expect(parser.getCallPoint(ctxMock)).toBe(JSON.stringify({ cmd: 'message' }));
     });
   });
   describe('getCallerIp', () => {
@@ -54,19 +52,13 @@ describe('NatsParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
   describe('getProtocol', () => {

--- a/packages/platform-rabbitmq/test/rabbit-interceptor.service.spec.ts
+++ b/packages/platform-rabbitmq/test/rabbit-interceptor.service.spec.ts
@@ -22,9 +22,7 @@ describe('RabbitMqParser', () => {
           }),
         }),
       });
-      expect(parser.getCallPoint(ctxMock)).toBe(
-        JSON.stringify({ cmd: 'message' }),
-      );
+      expect(parser.getCallPoint(ctxMock)).toBe(JSON.stringify({ cmd: 'message' }));
     });
   });
   describe('getCallerIp', () => {
@@ -54,19 +52,13 @@ describe('RabbitMqParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
   describe('getProtocol', () => {

--- a/packages/platform-redis/test/redis-interceptor.service.spec.ts
+++ b/packages/platform-redis/test/redis-interceptor.service.spec.ts
@@ -68,19 +68,13 @@ describe('RedisParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
 });

--- a/packages/platform-socket.io/test/socket-io-interceptor.service.spec.ts
+++ b/packages/platform-socket.io/test/socket-io-interceptor.service.spec.ts
@@ -62,19 +62,13 @@ describe('SocketIOParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
 });

--- a/packages/platform-tcp/test/tcp-interceptor.service.spec.ts
+++ b/packages/platform-tcp/test/tcp-interceptor.service.spec.ts
@@ -76,19 +76,13 @@ describe('TcpParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
-      expect(
-        parser.getStatus(createMock<ExecutionContext>(), false, new Error()),
-      ).toBe('500');
+      expect(parser.getStatus(createMock<ExecutionContext>(), false, new Error())).toBe('500');
     });
     it('should return a 200 in color', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
 });

--- a/packages/platform-ws/tests/ws-interceptor.service.spec.ts
+++ b/packages/platform-ws/tests/ws-interceptor.service.spec.ts
@@ -62,23 +62,15 @@ describe('WsParser', () => {
   });
   describe('getStatus', () => {
     it('should return a 200', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe(
-        '200',
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), false)).toBe('200');
     });
     it('should return a 500', () => {
       expect(
-        parser.getStatus(
-          createMock<ExecutionContext>(),
-          false,
-          new BadRequestException(),
-        ),
+        parser.getStatus(createMock<ExecutionContext>(), false, new BadRequestException()),
       ).toBe('500');
     });
     it('should return a 200 in green', () => {
-      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(
-        color.green(200),
-      );
+      expect(parser.getStatus(createMock<ExecutionContext>(), true)).toBe(color.green(200));
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -56,9 +56,9 @@
     rxjs "6.5.4"
 
 "@apollo/client@^3.1.5":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.0.tgz#d16ea4384a2126bf60e7d87b0a6c6df00382220b"
-  integrity sha512-6ISMYW9QpEykJAkN6ZZteTkXXwtYSPGbh+4iBZ478p/Eox1JOMGYlqosGgMGv2oduug9SnsR65y0iCAxKOFGiQ==
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@apollo/client/-/client-3.2.5.tgz#24e0a6faa1d231ab44807af237c6227410c75c4d"
+  integrity sha512-zpruxnFMz6K94gs2pqc3sidzFDbQpKT5D6P/J/I9s8ekHZ5eczgnRp6pqXC86Bh7+44j/btpmOT0kwiboyqTnA==
   dependencies:
     "@graphql-typed-document-node/core" "^3.0.0"
     "@types/zen-observable" "^0.8.0"
@@ -67,10 +67,9 @@
     fast-json-stable-stringify "^2.0.0"
     graphql-tag "^2.11.0"
     hoist-non-react-statics "^3.3.2"
-    optimism "^0.12.1"
+    optimism "^0.13.0"
     prop-types "^15.7.2"
     symbol-observable "^2.0.0"
-    terser "^5.2.0"
     ts-invariant "^0.4.4"
     tslib "^1.10.0"
     zen-observable "^0.8.14"
@@ -158,18 +157,18 @@
     "@babel/highlight" "^7.10.4"
 
 "@babel/core@^7.0.0":
-  version "7.11.6"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.11.6.tgz#3a9455dc7387ff1bac45770650bc13ba04a15651"
-  integrity sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.12.3.tgz#1b436884e1e3bff6fb1328dc02b208759de92ad8"
+  integrity sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.11.6"
-    "@babel/helper-module-transforms" "^7.11.0"
-    "@babel/helpers" "^7.10.4"
-    "@babel/parser" "^7.11.5"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-module-transforms" "^7.12.1"
+    "@babel/helpers" "^7.12.1"
+    "@babel/parser" "^7.12.3"
     "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.11.5"
-    "@babel/types" "^7.11.5"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
     gensync "^1.0.0-beta.1"
@@ -210,12 +209,12 @@
     jsesc "^2.5.1"
     source-map "^0.6.1"
 
-"@babel/generator@^7.11.5", "@babel/generator@^7.11.6", "@babel/generator@^7.5.0":
-  version "7.11.6"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.6.tgz#b868900f81b163b4d464ea24545c61cbac4dc620"
-  integrity sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==
+"@babel/generator@^7.11.5", "@babel/generator@^7.12.1", "@babel/generator@^7.5.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.1.tgz#0d70be32bdaa03d7c51c8597dda76e0df1f15468"
+  integrity sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==
   dependencies:
-    "@babel/types" "^7.11.5"
+    "@babel/types" "^7.12.1"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -226,14 +225,14 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
-"@babel/helper-builder-react-jsx-experimental@^7.10.4":
-  version "7.11.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.11.5.tgz#4ea43dd63857b0a35cd1f1b161dc29b43414e79f"
-  integrity sha512-Vc4aPJnRZKWfzeCBsqTBnzulVNjABVdahSPhtdMD3Vs80ykx4a87jTHtF/VR+alSrDmNvat7l13yrRHauGcHVw==
+"@babel/helper-builder-react-jsx-experimental@^7.12.1":
+  version "7.12.4"
+  resolved "https://registry.yarnpkg.com/@babel/helper-builder-react-jsx-experimental/-/helper-builder-react-jsx-experimental-7.12.4.tgz#55fc1ead5242caa0ca2875dcb8eed6d311e50f48"
+  integrity sha512-AjEa0jrQqNk7eDQOo0pTfUOwQBMF+xVqrausQwT9/rTKy0g04ggFNaJpaE09IQMn9yExluigWMJcj0WC7bq+Og==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
-    "@babel/helper-module-imports" "^7.10.4"
-    "@babel/types" "^7.11.5"
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-builder-react-jsx@^7.10.4":
   version "7.10.4"
@@ -243,16 +242,15 @@
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/helper-create-class-features-plugin@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.5.tgz#9f61446ba80e8240b0a5c85c6fdac8459d6f259d"
-  integrity sha512-0nkdeijB7VlZoLT3r/mY3bUkw3T8WG/hNw+FATs/6+pG2039IJWjTYL0VTISqsNHMUTEnwbVnc89WIJX9Qed0A==
+"@babel/helper-create-class-features-plugin@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.12.1.tgz#3c45998f431edd4a9214c5f1d3ad1448a6137f6e"
+  integrity sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
   dependencies:
     "@babel/helper-function-name" "^7.10.4"
-    "@babel/helper-member-expression-to-functions" "^7.10.5"
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
     "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
 
 "@babel/helper-define-map@^7.10.4":
@@ -280,21 +278,21 @@
   dependencies:
     "@babel/types" "^7.10.4"
 
-"@babel/helper-member-expression-to-functions@^7.10.4", "@babel/helper-member-expression-to-functions@^7.10.5":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz#ae69c83d84ee82f4b42f96e2a09410935a8f26df"
-  integrity sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==
+"@babel/helper-member-expression-to-functions@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz#fba0f2fcff3fba00e6ecb664bb5e6e26e2d6165c"
+  integrity sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==
   dependencies:
-    "@babel/types" "^7.11.0"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-module-imports@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz#4c5c54be04bd31670a7382797d75b9fa2e5b5620"
-  integrity sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==
+"@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz#1644c01591a15a2f084dd6d092d9430eb1d1216c"
+  integrity sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==
   dependencies:
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.10.5", "@babel/helper-module-transforms@^7.11.0":
+"@babel/helper-module-transforms@^7.10.5":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz#b16f250229e47211abdd84b34b64737c2ab2d359"
   integrity sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==
@@ -305,6 +303,21 @@
     "@babel/helper-split-export-declaration" "^7.11.0"
     "@babel/template" "^7.10.4"
     "@babel/types" "^7.11.0"
+    lodash "^4.17.19"
+
+"@babel/helper-module-transforms@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz#7954fec71f5b32c48e4b303b437c34453fd7247c"
+  integrity sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
+  dependencies:
+    "@babel/helper-module-imports" "^7.12.1"
+    "@babel/helper-replace-supers" "^7.12.1"
+    "@babel/helper-simple-access" "^7.12.1"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/helper-validator-identifier" "^7.10.4"
+    "@babel/template" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
     lodash "^4.17.19"
 
 "@babel/helper-optimise-call-expression@^7.10.4":
@@ -319,30 +332,29 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.4.tgz#2f75a831269d4f677de49986dff59927533cf375"
   integrity sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
 
-"@babel/helper-replace-supers@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz#d585cd9388ea06e6031e4cd44b6713cbead9e6cf"
-  integrity sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==
+"@babel/helper-replace-supers@^7.10.4", "@babel/helper-replace-supers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz#f15c9cc897439281891e11d5ce12562ac0cf3fa9"
+  integrity sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.10.4"
+    "@babel/helper-member-expression-to-functions" "^7.12.1"
     "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-simple-access@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz#0f5ccda2945277a2a7a2d3a821e15395edcf3461"
-  integrity sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==
+"@babel/helper-simple-access@^7.10.4", "@babel/helper-simple-access@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz#32427e5aa61547d38eb1e6eaf5fd1426fdad9136"
+  integrity sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
   dependencies:
-    "@babel/template" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/types" "^7.12.1"
 
-"@babel/helper-skip-transparent-expression-wrappers@^7.11.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.11.0.tgz#eec162f112c2f58d3af0af125e3bb57665146729"
-  integrity sha512-0XIdiQln4Elglgjbwo9wuJpL/K7AGCY26kmEt0+pRP0TAj4jjyNq1MjoRvikrTVqKcx4Gysxt4cXvVFXP/JO2Q==
+"@babel/helper-skip-transparent-expression-wrappers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.12.1.tgz#462dc63a7e435ade8468385c63d2b84cce4b3cbf"
+  integrity sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
   dependencies:
-    "@babel/types" "^7.11.0"
+    "@babel/types" "^7.12.1"
 
 "@babel/helper-split-export-declaration@^7.10.4", "@babel/helper-split-export-declaration@^7.11.0":
   version "7.11.0"
@@ -356,14 +368,14 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz#a78c7a7251e01f616512d31b10adcf52ada5e0d2"
   integrity sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==
 
-"@babel/helpers@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.10.4.tgz#2abeb0d721aff7c0a97376b9e1f6f65d7a475044"
-  integrity sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==
+"@babel/helpers@^7.10.4", "@babel/helpers@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.1.tgz#8a8261c1d438ec18cb890434df4ec768734c1e79"
+  integrity sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==
   dependencies:
     "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.10.4"
-    "@babel/types" "^7.10.4"
+    "@babel/traverse" "^7.12.1"
+    "@babel/types" "^7.12.1"
 
 "@babel/highlight@^7.10.4":
   version "7.10.4"
@@ -374,10 +386,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@7.11.5", "@babel/parser@^7.0.0", "@babel/parser@^7.10.4", "@babel/parser@^7.10.5", "@babel/parser@^7.11.5":
+"@babel/parser@7.11.5", "@babel/parser@^7.10.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.5.tgz#c7ff6303df71080ec7a4f5b8c003c58f1cf51037"
   integrity sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q==
+
+"@babel/parser@^7.0.0", "@babel/parser@^7.10.4", "@babel/parser@^7.11.5", "@babel/parser@^7.12.1", "@babel/parser@^7.12.3":
+  version "7.12.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
+  integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
 
 "@babel/parser@^7.1.0":
   version "7.10.5"
@@ -385,21 +402,21 @@
   integrity sha512-wfryxy4bE1UivvQKSQDU4/X6dr+i8bctjUjj8Zyt3DQy7NtPizJXT8M52nqpNKL+nq2PW8lxk4ZqLj0fD4B4hQ==
 
 "@babel/plugin-proposal-class-properties@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.10.4.tgz#a33bf632da390a59c7a8c570045d1115cd778807"
-  integrity sha512-vhwkEROxzcHGNu2mzUC0OFFNXdZ4M23ib8aRRcJSsW8BZK9pQMD7QB7csl97NBbgGZO7ZyHUyKDnxzOaP4IrCg==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-class-properties/-/plugin-proposal-class-properties-7.12.1.tgz#a082ff541f2a29a4821065b8add9346c0c16e5de"
+  integrity sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
   dependencies:
-    "@babel/helper-create-class-features-plugin" "^7.10.4"
+    "@babel/helper-create-class-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-proposal-object-rest-spread@^7.0.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.11.0.tgz#bd81f95a1f746760ea43b6c2d3d62b11790ad0af"
-  integrity sha512-wzch41N4yztwoRw0ak+37wxwJM2oiIiy6huGCoqkvSTA9acYWcPfn9Y4aJqmFFJ70KTJUu29f3DQ43uJ9HXzEA==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.12.1.tgz#def9bd03cea0f9b72283dac0ec22d289c7691069"
+  integrity sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-object-rest-spread" "^7.8.0"
-    "@babel/plugin-transform-parameters" "^7.10.4"
+    "@babel/plugin-transform-parameters" "^7.12.1"
 
 "@babel/plugin-syntax-async-generators@^7.8.4":
   version "7.8.4"
@@ -415,17 +432,24 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-class-properties@^7.0.0", "@babel/plugin-syntax-class-properties@^7.8.3":
+"@babel/plugin-syntax-class-properties@^7.0.0":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.1.tgz#bcb297c5366e79bebadef509549cd93b04f19978"
+  integrity sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.10.4"
+
+"@babel/plugin-syntax-class-properties@^7.8.3":
   version "7.10.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.10.4.tgz#6644e6a0baa55a61f9e3231f6c9eeb6ee46c124c"
   integrity sha512-GCSBF7iUle6rNugfURwNmCGG3Z/2+opxAMLs1nND4bhEG5PuxTIggDBoeYYSujAlLtsupzOHYJQgPS3pivwXIA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.10.4.tgz#53351dd7ae01995e567d04ce42af1a6e0ba846a6"
-  integrity sha512-yxQsX1dJixF4qEEdzVbst3SZQ58Nrooz8NV9Z9GL4byTE25BvJgl5lf0RECUf0fh28rZBb/RYTWn/eeKwCMrZQ==
+"@babel/plugin-syntax-flow@^7.0.0", "@babel/plugin-syntax-flow@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.12.1.tgz#a77670d9abe6d63e8acadf4c31bb1eb5a506bbdd"
+  integrity sha512-1lBLLmtxrwpm4VKmtVFselI/P3pX+G63fAtUUt6b2Nzgao77KNDwyuRt90Mj2/9pKobtt68FdvjfqohZjg/FCA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -443,10 +467,10 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.10.4":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.10.4.tgz#39abaae3cbf710c4373d8429484e6ba21340166c"
-  integrity sha512-KCg9mio9jwiARCB7WAcQ7Y1q+qicILjoK8LP/VkPkEKaf5dkaZZK1EcTe91a3JJlZ3qy6L5s9X52boEYi8DM9g==
+"@babel/plugin-syntax-jsx@^7.0.0", "@babel/plugin-syntax-jsx@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.12.1.tgz#9d9d357cc818aa7ae7935917c1257f67677a0926"
+  integrity sha512-1yRi7yAtB0ETgxdY9ti/p2TivUxJkTdhu/ZbF9MshVGqOx1TdB3b7xCXs49Fupgg50N45KcAsRP/ZqWjs9SRjg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
@@ -493,168 +517,166 @@
     "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-transform-arrow-functions@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.10.4.tgz#e22960d77e697c74f41c501d44d73dbf8a6a64cd"
-  integrity sha512-9J/oD1jV0ZCBcgnoFWFq1vJd4msoKb/TCpGNFyyLt0zABdcvgK3aYikZ8HjzB14c26bc7E3Q1yugpwGy2aTPNA==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-arrow-functions/-/plugin-transform-arrow-functions-7.12.1.tgz#8083ffc86ac8e777fbe24b5967c4b2521f3cb2b3"
+  integrity sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-block-scoped-functions@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.10.4.tgz#1afa595744f75e43a91af73b0d998ecfe4ebc2e8"
-  integrity sha512-WzXDarQXYYfjaV1szJvN3AD7rZgZzC1JtjJZ8dMHUyiK8mxPRahynp14zzNjU3VkPqPsO38CzxiWO1c9ARZ8JA==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoped-functions/-/plugin-transform-block-scoped-functions-7.12.1.tgz#f2a1a365bde2b7112e0a6ded9067fdd7c07905d9"
+  integrity sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-block-scoping@^7.0.0":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.11.1.tgz#5b7efe98852bef8d652c0b28144cd93a9e4b5215"
-  integrity sha512-00dYeDE0EVEHuuM+26+0w/SCL0BH2Qy7LwHuI4Hi4MH5gkC8/AqMN5uWFJIsoXZrAphiMm1iXzBw6L2T+eA0ew==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.12.1.tgz#f0ee727874b42a208a48a586b84c3d222c2bbef1"
+  integrity sha512-zJyAC9sZdE60r1nVQHblcfCj29Dh2Y0DOvlMkcqSo0ckqjiCwNiUezUKw+RjOCwGfpLRwnAeQ2XlLpsnGkvv9w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-classes@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.10.4.tgz#405136af2b3e218bc4a1926228bc917ab1a0adc7"
-  integrity sha512-2oZ9qLjt161dn1ZE0Ms66xBncQH4In8Sqw1YWgBUZuGVJJS5c0OFZXL6dP2MRHrkU/eKhWg8CzFJhRQl50rQxA==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-classes/-/plugin-transform-classes-7.12.1.tgz#65e650fcaddd3d88ddce67c0f834a3d436a32db6"
+  integrity sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-define-map" "^7.10.4"
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-optimise-call-expression" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
     "@babel/helper-split-export-declaration" "^7.10.4"
     globals "^11.1.0"
 
 "@babel/plugin-transform-computed-properties@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.10.4.tgz#9ded83a816e82ded28d52d4b4ecbdd810cdfc0eb"
-  integrity sha512-JFwVDXcP/hM/TbyzGq3l/XWGut7p46Z3QvqFMXTfk6/09m7xZHJUN9xHfsv7vqqD4YnfI5ueYdSJtXqqBLyjBw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.12.1.tgz#d68cf6c9b7f838a8a4144badbe97541ea0904852"
+  integrity sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-destructuring@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.10.4.tgz#70ddd2b3d1bea83d01509e9bb25ddb3a74fc85e5"
-  integrity sha512-+WmfvyfsyF603iPa6825mq6Qrb7uLjTOsa3XOFzlYcYDHSS4QmpOWOL0NNBY5qMbvrcf3tq0Cw+v4lxswOBpgA==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.12.1.tgz#b9a570fe0d0a8d460116413cb4f97e8e08b2f847"
+  integrity sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-flow-strip-types@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.10.4.tgz#c497957f09e86e3df7296271e9eb642876bf7788"
-  integrity sha512-XTadyuqNst88UWBTdLjM+wEY7BFnY2sYtPyAidfC7M/QaZnSuIZpMvLxqGT7phAcnGyWh/XQFLKcGf04CnvxSQ==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-flow-strip-types/-/plugin-transform-flow-strip-types-7.12.1.tgz#8430decfa7eb2aea5414ed4a3fa6e1652b7d77c4"
+  integrity sha512-8hAtkmsQb36yMmEtk2JZ9JnVyDSnDOdlB+0nEGzIDLuK4yR3JcEjfuFPYkdEPSh8Id+rAMeBEn+X0iVEyho6Hg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-flow" "^7.10.4"
+    "@babel/plugin-syntax-flow" "^7.12.1"
 
 "@babel/plugin-transform-for-of@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.10.4.tgz#c08892e8819d3a5db29031b115af511dbbfebae9"
-  integrity sha512-ItdQfAzu9AlEqmusA/65TqJ79eRcgGmpPPFvBnGILXZH975G0LNjP1yjHvGgfuCxqrPPueXOPe+FsvxmxKiHHQ==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.12.1.tgz#07640f28867ed16f9511c99c888291f560921cfa"
+  integrity sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-function-name@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.10.4.tgz#6a467880e0fc9638514ba369111811ddbe2644b7"
-  integrity sha512-OcDCq2y5+E0dVD5MagT5X+yTRbcvFjDI2ZVAottGH6tzqjx/LKpgkUepu3hp/u4tZBzxxpNGwLsAvGBvQ2mJzg==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-function-name/-/plugin-transform-function-name-7.12.1.tgz#2ec76258c70fe08c6d7da154003a480620eba667"
+  integrity sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==
   dependencies:
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-literals@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.10.4.tgz#9f42ba0841100a135f22712d0e391c462f571f3c"
-  integrity sha512-Xd/dFSTEVuUWnyZiMu76/InZxLTYilOSr1UlHV+p115Z/Le2Fi1KXkJUYz0b42DfndostYlPub3m8ZTQlMaiqQ==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-literals/-/plugin-transform-literals-7.12.1.tgz#d73b803a26b37017ddf9d3bb8f4dc58bfb806f57"
+  integrity sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-member-expression-literals@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.10.4.tgz#b1ec44fcf195afcb8db2c62cd8e551c881baf8b7"
-  integrity sha512-0bFOvPyAoTBhtcJLr9VcwZqKmSjFml1iVxvPL0ReomGU53CX53HsM4h2SzckNdkQcHox1bpAqzxBI1Y09LlBSw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-member-expression-literals/-/plugin-transform-member-expression-literals-7.12.1.tgz#496038602daf1514a64d43d8e17cbb2755e0c3ad"
+  integrity sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-modules-commonjs@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.10.4.tgz#66667c3eeda1ebf7896d41f1f16b17105a2fbca0"
-  integrity sha512-Xj7Uq5o80HDLlW64rVfDBhao6OX89HKUmb+9vWYaLXBZOma4gA6tw4Ni1O5qVDoZWUV0fxMYA0aYzOawz0l+1w==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.12.1.tgz#fa403124542636c786cf9b460a0ffbb48a86e648"
+  integrity sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
   dependencies:
-    "@babel/helper-module-transforms" "^7.10.4"
+    "@babel/helper-module-transforms" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-simple-access" "^7.10.4"
+    "@babel/helper-simple-access" "^7.12.1"
     babel-plugin-dynamic-import-node "^2.3.3"
 
 "@babel/plugin-transform-object-super@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.10.4.tgz#d7146c4d139433e7a6526f888c667e314a093894"
-  integrity sha512-5iTw0JkdRdJvr7sY0vHqTpnruUpTea32JHmq/atIWqsnNussbRzjEDyWep8UNztt1B5IusBYg8Irb0bLbiEBCQ==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-object-super/-/plugin-transform-object-super-7.12.1.tgz#4ea08696b8d2e65841d0c7706482b048bed1066e"
+  integrity sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-replace-supers" "^7.10.4"
+    "@babel/helper-replace-supers" "^7.12.1"
 
-"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.10.4":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.10.5.tgz#59d339d58d0b1950435f4043e74e2510005e2c4a"
-  integrity sha512-xPHwUj5RdFV8l1wuYiu5S9fqWGM2DrYc24TMvUiRrPVm+SM3XeqU9BcokQX/kEUe+p2RBwy+yoiR1w/Blq6ubw==
+"@babel/plugin-transform-parameters@^7.0.0", "@babel/plugin-transform-parameters@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.12.1.tgz#d2e963b038771650c922eff593799c96d853255d"
+  integrity sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-property-literals@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.10.4.tgz#f6fe54b6590352298785b83edd815d214c42e3c0"
-  integrity sha512-ofsAcKiUxQ8TY4sScgsGeR2vJIsfrzqvFb9GvJ5UdXDzl+MyYCaBj/FGzXuv7qE0aJcjWMILny1epqelnFlz8g==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-property-literals/-/plugin-transform-property-literals-7.12.1.tgz#41bc81200d730abb4456ab8b3fbd5537b59adecd"
+  integrity sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-react-display-name@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.10.4.tgz#b5795f4e3e3140419c3611b7a2a3832b9aef328d"
-  integrity sha512-Zd4X54Mu9SBfPGnEcaGcOrVAYOtjT2on8QZkLKEq1S/tHexG39d9XXGZv19VfRrDjPJzFmPfTAqOQS1pfFOujw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.12.1.tgz#1cbcd0c3b1d6648c55374a22fc9b6b7e5341c00d"
+  integrity sha512-cAzB+UzBIrekfYxyLlFqf/OagTvHLcVBb5vpouzkYkBclRPraiygVnafvAoipErZLI8ANv8Ecn6E/m5qPXD26w==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-react-jsx@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.10.4.tgz#673c9f913948764a4421683b2bef2936968fddf2"
-  integrity sha512-L+MfRhWjX0eI7Js093MM6MacKU4M6dnCRa/QPDwYMxjljzSCzzlzKzj9Pk4P3OtrPcxr2N3znR419nr3Xw+65A==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz#c2d96c77c2b0e4362cc4e77a43ce7c2539d478cb"
+  integrity sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==
   dependencies:
     "@babel/helper-builder-react-jsx" "^7.10.4"
-    "@babel/helper-builder-react-jsx-experimental" "^7.10.4"
+    "@babel/helper-builder-react-jsx-experimental" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/plugin-syntax-jsx" "^7.10.4"
+    "@babel/plugin-syntax-jsx" "^7.12.1"
 
 "@babel/plugin-transform-shorthand-properties@^7.0.0":
-  version "7.10.4"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.10.4.tgz#9fd25ec5cdd555bb7f473e5e6ee1c971eede4dd6"
-  integrity sha512-AC2K/t7o07KeTIxMoHneyX90v3zkm5cjHJEokrPEAGEy3UCp8sLKfnfOIGdZ194fyN4wfX/zZUWT9trJZ0qc+Q==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.1.tgz#0bf9cac5550fce0cfdf043420f661d645fdc75e3"
+  integrity sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-spread@^7.0.0":
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.11.0.tgz#fa84d300f5e4f57752fe41a6d1b3c554f13f17cc"
-  integrity sha512-UwQYGOqIdQJe4aWNyS7noqAnN2VbaczPLiEtln+zPowRNlD+79w3oi2TWfYe0eZgd+gjZCbsydN7lzWysDt+gw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.12.1.tgz#527f9f311be4ec7fdc2b79bb89f7bf884b3e1e1e"
+  integrity sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
-    "@babel/helper-skip-transparent-expression-wrappers" "^7.11.0"
+    "@babel/helper-skip-transparent-expression-wrappers" "^7.12.1"
 
 "@babel/plugin-transform-template-literals@^7.0.0":
-  version "7.10.5"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.10.5.tgz#78bc5d626a6642db3312d9d0f001f5e7639fde8c"
-  integrity sha512-V/lnPGIb+KT12OQikDvgSuesRX14ck5FfJXt6+tXhdkJ+Vsd0lDCVtF6jcB4rNClYFzaB2jusZ+lNISDk2mMMw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-template-literals/-/plugin-transform-template-literals-7.12.1.tgz#b43ece6ed9a79c0c71119f576d299ef09d942843"
+  integrity sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.10.4"
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/runtime@^7.0.0", "@babel/runtime@^7.11.2":
-  version "7.11.2"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.11.2.tgz#f549c13c754cc40b87644b9fa9f09a6a95fe0736"
-  integrity sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
+  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -667,7 +689,7 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/traverse@7.11.5", "@babel/traverse@^7.0.0", "@babel/traverse@^7.10.4", "@babel/traverse@^7.10.5", "@babel/traverse@^7.11.5":
+"@babel/traverse@7.11.5", "@babel/traverse@^7.10.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.5.tgz#be777b93b518eb6d76ee2e1ea1d143daa11e61c3"
   integrity sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==
@@ -678,6 +700,21 @@
     "@babel/helper-split-export-declaration" "^7.11.0"
     "@babel/parser" "^7.11.5"
     "@babel/types" "^7.11.5"
+    debug "^4.1.0"
+    globals "^11.1.0"
+    lodash "^4.17.19"
+
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
+  integrity sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/generator" "^7.12.1"
+    "@babel/helper-function-name" "^7.10.4"
+    "@babel/helper-split-export-declaration" "^7.11.0"
+    "@babel/parser" "^7.12.1"
+    "@babel/types" "^7.12.1"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.19"
@@ -697,10 +734,19 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/types@7.11.5", "@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5":
+"@babel/types@7.11.5":
   version "7.11.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.5.tgz#d9de577d01252d77c6800cee039ee64faf75662d"
   integrity sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.10.4"
+    lodash "^4.17.19"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.0.0", "@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
+  integrity sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -881,10 +927,10 @@
     is-absolute "^1.0.0"
     is-negated-glob "^1.0.0"
 
-"@eslint/eslintrc@^0.1.3":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.1.3.tgz#7d1a2b2358552cc04834c0979bd4275362e37085"
-  integrity sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==
+"@eslint/eslintrc@^0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@eslint/eslintrc/-/eslintrc-0.2.0.tgz#bc7e3c4304d4c8720968ccaee793087dfb5fe6b4"
+  integrity sha512-+cIGPCBdLCzqxdtwppswP+zTsH9BOIGzAeKfBIbtb4gW/giMlfMwP0HUSFfhzh20f9u8uZ8hOp62+4GPquTbwQ==
   dependencies:
     ajv "^6.12.4"
     debug "^4.1.1"
@@ -983,12 +1029,12 @@
   resolved "https://registry.yarnpkg.com/@golevelup/ts-jest/-/ts-jest-0.3.0.tgz#7283286304cf97b17360e78e3ad1d66e719c432f"
   integrity sha512-/PRdR75+w3slJ/kye8TZqhVCaKymd8xpKChk2CETtsqrqbCCtmIq2ujMc8j7+vhI42umcgDUyyYpVHrnIDsIcw==
 
-"@graphql-tools/batch-delegate@^6.2.5":
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-delegate/-/batch-delegate-6.2.5.tgz#c23f25fdb0e5deb6d6964e7b5ea26cfb628c2143"
-  integrity sha512-Txh2m9Fjmv1eEvR9eSyKPJuLJQEXTPUVy6JVDisIR16e8DWCE9h9TiI/OK9YB+ZCXrGs6qsnMgFKCoLAlhf9yQ==
+"@graphql-tools/batch-delegate@^6.2.4", "@graphql-tools/batch-delegate@^6.2.6":
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/batch-delegate/-/batch-delegate-6.2.6.tgz#fbea98dc825f87ef29ea5f3f371912c2a2aa2f2c"
+  integrity sha512-QUoE9pQtkdNPFdJHSnBhZtUfr3M7pIRoXoMR+TG7DK2Y62ISKbT/bKtZEUU1/2v5uqd5WVIvw9dF8gHDSJAsSA==
   dependencies:
-    "@graphql-tools/delegate" "^7.0.0"
+    "@graphql-tools/delegate" "^6.2.4"
     dataloader "2.0.0"
     tslib "~2.0.1"
 
@@ -1002,7 +1048,7 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/code-file-loader@^6.2.5":
+"@graphql-tools/code-file-loader@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/code-file-loader/-/code-file-loader-6.2.5.tgz#02832503e96c6c537083570208bd55ca1fbfaa68"
   integrity sha512-KMy8c/I4NeQZUI9InydR14qP1pqPeJfgVJLri0RgJRWDiLAj/nIb2oDioN9AgBX3XYNijJT+pH0//B5EOO0BiA==
@@ -1010,6 +1056,18 @@
     "@graphql-tools/graphql-tag-pluck" "^6.2.6"
     "@graphql-tools/utils" "^7.0.0"
     fs-extra "9.0.1"
+    tslib "~2.0.1"
+
+"@graphql-tools/delegate@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/delegate/-/delegate-6.2.4.tgz#db553b63eb9512d5eb5bbfdfcd8cb1e2b534699c"
+  integrity sha512-mXe6DfoWmq49kPcDrpKHgC2DSWcD5q0YCaHHoXYPAOlnLH8VMTY8BxcE8y/Do2eyg+GLcwAcrpffVszWMwqw0w==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.6"
+    "@graphql-tools/schema" "^6.2.4"
+    "@graphql-tools/utils" "^6.2.4"
+    dataloader "2.0.0"
+    is-promise "4.0.0"
     tslib "~2.0.1"
 
 "@graphql-tools/delegate@^7.0.0":
@@ -1025,7 +1083,7 @@
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/git-loader@^6.2.5":
+"@graphql-tools/git-loader@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/git-loader/-/git-loader-6.2.5.tgz#a4b3e8826964e1752a3d3a5a33a44b70b9694353"
   integrity sha512-WOQDSzazyPZMZUvymHBv5oZ80/mS7tc8XUNy2GmU5My8YRny5zu4fEgP4vQeFcD1trG3uoHUaJPGF7Mmvp6Yhg==
@@ -1034,7 +1092,7 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/github-loader@^6.2.5":
+"@graphql-tools/github-loader@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/github-loader/-/github-loader-6.2.5.tgz#460dff6f5bbaa26957a5ea3be4f452b89cc6a44b"
   integrity sha512-DLuQmYeNNdPo8oWus8EePxWCfCAyUXPZ/p1PWqjrX/NGPyH2ZObdqtDAfRHztljt0F/qkBHbGHCEk2TKbRZTRw==
@@ -1044,7 +1102,7 @@
     cross-fetch "3.0.6"
     tslib "~2.0.1"
 
-"@graphql-tools/graphql-file-loader@^6.2.5":
+"@graphql-tools/graphql-file-loader@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-file-loader/-/graphql-file-loader-6.2.5.tgz#831289675e5f446baa19afbc0af8ea6bc94063bf"
   integrity sha512-vYDn71FHqwCxWgw8swoVOsD5C0xGz/Lw4zUQnPcgZfAzhAAwl6e/rVWl/HF1UNNSf5CSZu+2oidjOWCI5Wl6Gg==
@@ -1054,7 +1112,7 @@
     fs-extra "9.0.1"
     tslib "~2.0.1"
 
-"@graphql-tools/graphql-tag-pluck@^6.2.6":
+"@graphql-tools/graphql-tag-pluck@^6.2.4", "@graphql-tools/graphql-tag-pluck@^6.2.6":
   version "6.2.6"
   resolved "https://registry.yarnpkg.com/@graphql-tools/graphql-tag-pluck/-/graphql-tag-pluck-6.2.6.tgz#a7dba969385344d8dd29fa02b4e7175f053d6f60"
   integrity sha512-cPYtsBr+W48Hp+SkVdba5KQGPx+jWpDhf7ZX0ySpYGgf3iXCK5w6OZn7nn5AWlmUtMAp8LBLSMenGWcQIuiomw==
@@ -1076,7 +1134,7 @@
     resolve-from "5.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/json-file-loader@^6.2.5":
+"@graphql-tools/json-file-loader@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/json-file-loader/-/json-file-loader-6.2.5.tgz#1357d2efd2f416f44e0dd717da06463c29adbf60"
   integrity sha512-9LS7WuQdSHlRUvXD7ixt5aDpr3hWsueURHOaWe7T0xZ+KWMTw+LIRtWIliCRzbjNmZ+4ZhwHB3Vc1SO2bfYLgg==
@@ -1085,7 +1143,7 @@
     fs-extra "9.0.1"
     tslib "~2.0.1"
 
-"@graphql-tools/links@^6.2.5":
+"@graphql-tools/links@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/links/-/links-6.2.5.tgz#b172cadc4b7cbe27bfc1dc787651f92517f583bc"
   integrity sha512-XeGDioW7F+HK6HHD/zCeF0HRC9s12NfOXAKv1HC0J7D50F4qqMvhdS/OkjzLoBqsgh/Gm8icRc36B5s0rOA9ig==
@@ -1108,7 +1166,7 @@
     tslib "~2.0.1"
     unixify "1.0.0"
 
-"@graphql-tools/load@^6.2.5":
+"@graphql-tools/load@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/load/-/load-6.2.5.tgz#7dd0d34c8ce2cfb24f61c6beba2817d9afdd7f2b"
   integrity sha512-TpDgp+id0hhD1iMhdFSgWgWumdI/IpFWwouJeaEhEEAEBkdvH4W9gbBiJBSbPQwMPRNWx8/AZtry0cYKLW4lHg==
@@ -1132,7 +1190,7 @@
     "@graphql-tools/utils" "6.0.13"
     tslib "~2.0.0"
 
-"@graphql-tools/merge@^6.2.5":
+"@graphql-tools/merge@^6.2.4", "@graphql-tools/merge@^6.2.5":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/merge/-/merge-6.2.5.tgz#a03d6711f2a468b8de97c0fe9092469280ca66c9"
   integrity sha512-T2UEm7L5MeS1ggbGKBkdV9kTqLqSHQM13RrjPzIAYzkFL/mK837sf+oq8h2+R8B+senuHX8akUhMTcU85kcMvw==
@@ -1141,16 +1199,16 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/mock@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/mock/-/mock-7.0.0.tgz#b43858f47fedfbf7d8bbbf7d33e6acb64b8b7da7"
-  integrity sha512-ShO8D9HudgnhqoWeKb3iejGtPV8elFqSO1U0O70g3FH3W/CBW2abXfuyodBUevXVGIjyqzfkNzVtpIE0qiOVVQ==
+"@graphql-tools/mock@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/mock/-/mock-6.2.4.tgz#205323c51f89dd855d345d130c7713d0420909ea"
+  integrity sha512-O5Zvq/mcDZ7Ptky0IZ4EK9USmxV6FEVYq0Jxv2TI80kvxbCjt0tbEpZ+r1vIt1gZOXlAvadSHYyzWnUPh+1vkQ==
   dependencies:
-    "@graphql-tools/schema" "^7.0.0"
-    "@graphql-tools/utils" "^7.0.0"
+    "@graphql-tools/schema" "^6.2.4"
+    "@graphql-tools/utils" "^6.2.4"
     tslib "~2.0.1"
 
-"@graphql-tools/module-loader@^6.2.5":
+"@graphql-tools/module-loader@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/module-loader/-/module-loader-6.2.5.tgz#7ea914c590e0df10add354c0fab4c0726c27ad07"
   integrity sha512-tH7SMLKCoPJPkQ6lw3zhNbylOVkUWqSqV0JL4FzLRu5JTO9u/48KI8dldVIq+d8ZyCC1LIt7WoYLiVMCn/Uv/A==
@@ -1158,7 +1216,7 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/relay-operation-optimizer@^6.2.5":
+"@graphql-tools/relay-operation-optimizer@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/relay-operation-optimizer/-/relay-operation-optimizer-6.2.5.tgz#49ca28ce488200b08de06d26313b4d987a45c6b6"
   integrity sha512-i7iJl2/IbmgmoYVky0jhSMIfgaO8icYef2z/Y+0QUdkqBB6fwE2jfD3HrMlJzd45+eghtIj46Qjrp+Bns4o/TA==
@@ -1167,7 +1225,7 @@
     relay-compiler "10.0.1"
     tslib "~2.0.1"
 
-"@graphql-tools/resolvers-composition@^6.2.5":
+"@graphql-tools/resolvers-composition@^6.2.4":
   version "6.2.5"
   resolved "https://registry.yarnpkg.com/@graphql-tools/resolvers-composition/-/resolvers-composition-6.2.5.tgz#1c1819083304e6de42a104f01e4ecf8a00086ce8"
   integrity sha512-nhssXhF/2GHa2QDfatYpwfjaHJrAbCS7vuDtfECNqPDFFeekU83Mz3CLXaa6E4uEuSR07cUosFRaFgnA02Mg4w==
@@ -1184,6 +1242,14 @@
     "@graphql-tools/utils" "6.0.13"
     tslib "~2.0.0"
 
+"@graphql-tools/schema@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-6.2.4.tgz#cc4e9f5cab0f4ec48500e666719d99fc5042481d"
+  integrity sha512-rh+14lSY1q8IPbEv2J9x8UBFJ5NrDX9W5asXEUlPp+7vraLp/Tiox4GXdgyA92JhwpYco3nTf5Bo2JDMt1KnAQ==
+  dependencies:
+    "@graphql-tools/utils" "^6.2.4"
+    tslib "~2.0.1"
+
 "@graphql-tools/schema@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/schema/-/schema-7.0.0.tgz#f87e307d00a3d388f5c54d32f4697611396c0127"
@@ -1192,21 +1258,21 @@
     "@graphql-tools/utils" "^7.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/stitch@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@graphql-tools/stitch/-/stitch-7.0.0.tgz#48b578f0fa14db1f6b20d19a74af1029af2652c8"
-  integrity sha512-6gESTUUXPkRYyUMw+6eU/cPgZPQJC5Fbld9Km06DBm/kL94KR6Z979rE6MH1Ip5H1W5lUVCiwrigTaCbJu2e0A==
+"@graphql-tools/stitch@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/stitch/-/stitch-6.2.4.tgz#acfa6a577a33c0f02e4940ffff04753b23b87fd6"
+  integrity sha512-0C7PNkS7v7iAc001m7c1LPm5FUB0/DYw+s3OyCii6YYYHY8NwdI0roeOyeDGFJkFubWBQfjc3hoSyueKtU73mw==
   dependencies:
-    "@graphql-tools/batch-delegate" "^6.2.5"
-    "@graphql-tools/delegate" "^7.0.0"
-    "@graphql-tools/merge" "^6.2.5"
-    "@graphql-tools/schema" "^7.0.0"
-    "@graphql-tools/utils" "^7.0.0"
-    "@graphql-tools/wrap" "^7.0.0"
+    "@graphql-tools/batch-delegate" "^6.2.4"
+    "@graphql-tools/delegate" "^6.2.4"
+    "@graphql-tools/merge" "^6.2.4"
+    "@graphql-tools/schema" "^6.2.4"
+    "@graphql-tools/utils" "^6.2.4"
+    "@graphql-tools/wrap" "^6.2.4"
     is-promise "4.0.0"
     tslib "~2.0.1"
 
-"@graphql-tools/url-loader@^6.3.1":
+"@graphql-tools/url-loader@^6.2.4":
   version "6.3.1"
   resolved "https://registry.yarnpkg.com/@graphql-tools/url-loader/-/url-loader-6.3.1.tgz#7bf74fdb63f75e001c97d1248d19bf88eaba3b2b"
   integrity sha512-AnsGcWcO1dswdA/KH3J65nDetErZK6hnfxqdjRP44jP3H12LjksgEuSsIqD4x5dlFbwCn2whNd0ZeeS9QDsgtQ==
@@ -1229,6 +1295,15 @@
     "@ardatan/aggregate-error" "0.0.1"
     camel-case "4.1.1"
 
+"@graphql-tools/utils@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-6.2.4.tgz#38a2314d2e5e229ad4f78cca44e1199e18d55856"
+  integrity sha512-ybgZ9EIJE3JMOtTrTd2VcIpTXtDrn2q6eiYkeYMKRVh3K41+LZa6YnR2zKERTXqTWqhobROwLt4BZbw2O3Aeeg==
+  dependencies:
+    "@ardatan/aggregate-error" "0.0.6"
+    camel-case "4.1.1"
+    tslib "~2.0.1"
+
 "@graphql-tools/utils@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@graphql-tools/utils/-/utils-7.0.0.tgz#8af1982b4c55607e02e103230ad926c5f8b89fe2"
@@ -1236,6 +1311,17 @@
   dependencies:
     "@ardatan/aggregate-error" "0.0.6"
     camel-case "4.1.1"
+    tslib "~2.0.1"
+
+"@graphql-tools/wrap@^6.2.4":
+  version "6.2.4"
+  resolved "https://registry.yarnpkg.com/@graphql-tools/wrap/-/wrap-6.2.4.tgz#2709817da6e469753735a9fe038c9e99736b2c57"
+  integrity sha512-cyQgpybolF9DjL2QNOvTS1WDCT/epgYoiA8/8b3nwv5xmMBQ6/6nYnZwityCZ7njb7MMyk7HBEDNNlP9qNJDcA==
+  dependencies:
+    "@graphql-tools/delegate" "^6.2.4"
+    "@graphql-tools/schema" "^6.2.4"
+    "@graphql-tools/utils" "^6.2.4"
+    is-promise "4.0.0"
     tslib "~2.0.1"
 
 "@graphql-tools/wrap@^7.0.0":
@@ -1323,6 +1409,11 @@
     rimraf "^3.0.0"
     slash "^3.0.0"
     strip-ansi "^6.0.0"
+
+"@jest/create-cache-key-function@^26.5.0":
+  version "26.5.0"
+  resolved "https://registry.yarnpkg.com/@jest/create-cache-key-function/-/create-cache-key-function-26.5.0.tgz#1d07947adc51ea17766d9f0ccf5a8d6ea94c47dc"
+  integrity sha512-DJ+pEBUIqarrbv1W/C39f9YH0rJ4wsXZ/VC6JafJPlHW2HOucKceeaqTOQj9MEDQZjySxMLkOq5mfXZXNZcmWw==
 
 "@jest/environment@^26.6.1":
   version "26.6.1"
@@ -1437,28 +1528,6 @@
     slash "^3.0.0"
     source-map "^0.6.1"
     write-file-atomic "^3.0.0"
-
-"@jest/types@^26.3.0":
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.3.0.tgz#97627bf4bdb72c55346eef98e3b3f7ddc4941f71"
-  integrity sha512-BDPG23U0qDeAvU4f99haztXwdAg3hz4El95LkAM+tHAqqhiVzRpEGHHU8EDxT/AnxOrA65YjLBwDahdJ9pTLJQ==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
-
-"@jest/types@^26.6.0":
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.0.tgz#2c045f231bfd79d52514cda3fbc93ef46157fa6a"
-  integrity sha512-8pDeq/JVyAYw7jBGU83v8RMYAkdrRxLG3BGnAJuqaQAUd6GWBmND2uyl+awI88+hit48suLoLjNFtR+ZXxWaYg==
-  dependencies:
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^15.0.0"
-    chalk "^4.0.0"
 
 "@jest/types@^26.6.1":
   version "26.6.1"
@@ -2633,11 +2702,6 @@
     "@types/long" "*"
     "@types/node" "*"
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
 "@types/connect@*":
   version "3.4.33"
   resolved "https://registry.yarnpkg.com/@types/connect/-/connect-3.4.33.tgz#31610c901eca573b8713c3330abc6e6b9f588546"
@@ -2660,10 +2724,17 @@
     "@types/keygrip" "*"
     "@types/node" "*"
 
-"@types/cors@^2.8.4":
+"@types/cors@2.8.7":
   version "2.8.7"
   resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.7.tgz#ab2f47f1cba93bce27dfd3639b006cc0e5600889"
   integrity sha512-sOdDRU3oRS7LBNTIqwDkPJyq0lpHYcbMTt0TrjzsXbk/e37hcLTH6eZX7CdbDeN0yJJvzw9hFBZkbtCSbk/jAQ==
+  dependencies:
+    "@types/express" "*"
+
+"@types/cors@^2.8.4":
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/@types/cors/-/cors-2.8.8.tgz#317a8d8561995c60e35b9e0fcaa8d36660c98092"
+  integrity sha512-fO3gf3DxU2Trcbr75O7obVndW/X5k8rJNZkLXlQWStTHhP71PkRqjwPIEI0yMnJdg9R9OasjU+Bsr+Hr1xy/0w==
   dependencies:
     "@types/express" "*"
 
@@ -2675,9 +2746,18 @@
     "@types/node" "*"
 
 "@types/express-serve-static-core@*":
-  version "4.17.12"
-  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz#9a487da757425e4f267e7d1c5720226af7f89591"
-  integrity sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==
+  version "4.17.13"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz#d9af025e925fc8b089be37423b8d1eac781be084"
+  integrity sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==
+  dependencies:
+    "@types/node" "*"
+    "@types/qs" "*"
+    "@types/range-parser" "*"
+
+"@types/express-serve-static-core@4.17.9":
+  version "4.17.9"
+  resolved "https://registry.yarnpkg.com/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz#2d7b34dcfd25ec663c25c85d76608f8b249667f1"
+  integrity sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==
   dependencies:
     "@types/node" "*"
     "@types/qs" "*"
@@ -2726,14 +2806,14 @@
     "@types/node" "*"
 
 "@types/graphql-upload@^8.0.0":
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/@types/graphql-upload/-/graphql-upload-8.0.3.tgz#b371edb5f305a2a1f7b7843a890a2a7adc55c3ec"
-  integrity sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==
+  version "8.0.4"
+  resolved "https://registry.yarnpkg.com/@types/graphql-upload/-/graphql-upload-8.0.4.tgz#23a8ffb3d2fe6e0ee07e6f16ee9d9d5e995a2f4f"
+  integrity sha512-0TRyJD2o8vbkmJF8InppFcPVcXKk+Rvlg/xvpHBIndSJYpmDWfmtx/ZAtl4f3jR2vfarpTqYgj8MZuJssSoU7Q==
   dependencies:
     "@types/express" "*"
     "@types/fs-capacitor" "*"
     "@types/koa" "*"
-    graphql "^14.5.3"
+    graphql "^15.3.0"
 
 "@types/http-assert@*":
   version "1.5.1"
@@ -2800,9 +2880,9 @@
     "@types/koa" "*"
 
 "@types/koa@*":
-  version "2.11.4"
-  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.11.4.tgz#8af02a069a9f8e08fa47b8da28d982e652f69cfb"
-  integrity sha512-Etqs0kdqbuAsNr5k6mlZQelpZKVwMu9WPRHVVTLnceZlhr0pYmblRNJbCgoCMzKWWePldydU0AYEOX4Q9fnGUQ==
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.11.6.tgz#b7030caa6b44af801c2aea13ba77d74aff7484d5"
+  integrity sha512-BhyrMj06eQkk04C97fovEDQMpLpd2IxCB4ecitaXwOKGq78Wi2tooaDOWOFGajPk8IkQOAtMppApgSVkYe1F/A==
   dependencies:
     "@types/accepts" "*"
     "@types/content-disposition" "*"
@@ -2861,9 +2941,9 @@
   integrity sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==
 
 "@types/node@^10.1.0":
-  version "10.17.29"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.29.tgz#263b7013f9f4afa53585b199f9a4255d9613b178"
-  integrity sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA==
+  version "10.17.42"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-10.17.42.tgz#90dd71b26fe4f4e2929df6b07e72ef2e9648a173"
+  integrity sha512-HElxYF7C/MSkuvlaHB2c+82zhXiuO49Cq056Dol8AQuTph7oJtduo2n6J8rFa+YhJyNgQ/Lm20ZaxqD0vxU0+Q==
 
 "@types/node@^13.7.0":
   version "13.13.14"
@@ -2902,9 +2982,9 @@
   integrity sha512-IkVfat549ggtkZUthUzEX49562eGikhSYeVGX97SkMFn+sTZrgRewXjQ4tPKFPCykZHkX1Zfd9OoELGqKU2jJA==
 
 "@types/qs@*":
-  version "6.9.4"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.4.tgz#a59e851c1ba16c0513ea123830dd639a0a15cb6a"
-  integrity sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ==
+  version "6.9.5"
+  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.5.tgz#434711bdd49eb5ee69d90c1d67c354a9a8ecb18b"
+  integrity sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==
 
 "@types/range-parser@*":
   version "1.2.3"
@@ -2912,12 +2992,12 @@
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
 
 "@types/serve-static@*":
-  version "1.13.5"
-  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.5.tgz#3d25d941a18415d3ab092def846e135a08bbcf53"
-  integrity sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==
+  version "1.13.6"
+  resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.6.tgz#866b1b8dec41c36e28c7be40ac725b88be43c5c1"
+  integrity sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==
   dependencies:
-    "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+    "@types/node" "*"
 
 "@types/socket.io-client@^1.4.32":
   version "1.4.34"
@@ -3002,9 +3082,9 @@
   integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
 
 "@types/yargs@^15.0.0":
-  version "15.0.5"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.5.tgz#947e9a6561483bdee9adffc983e91a6902af8b79"
-  integrity sha512-Dk/IDOPtOgubt/IaevIUbTgV7doaKkoorvOyYM2CMwuDyP89bekI7H4xLIwunNYiK9jhCkmc6pUrJk3cj2AB9w==
+  version "15.0.9"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-15.0.9.tgz#524cd7998fe810cdb02f26101b699cccd156ff19"
+  integrity sha512-HmU8SeIRhZCWcnRskCs36Q1Q00KBV6Cqh/ora8WN1+22dY07AZdn6Gel8QZ3t26XYPImtcL8WV/eqjhVmMEw4g==
   dependencies:
     "@types/yargs-parser" "*"
 
@@ -3308,9 +3388,9 @@ acorn-globals@^6.0.0:
     acorn-walk "^7.1.1"
 
 acorn-jsx@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
-  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-walk@^7.1.1:
   version "7.2.0"
@@ -3328,9 +3408,9 @@ acorn@^7.1.1:
   integrity sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==
 
 acorn@^7.4.0:
-  version "7.4.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.0.tgz#e1ad486e6c54501634c6c397c5c121daa383607c"
-  integrity sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
 add-stream@^1.0.0:
   version "1.0.0"
@@ -3407,10 +3487,20 @@ ajv@6.12.3:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ajv@^6.1.0, ajv@^6.10.0, ajv@^6.10.2, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.12.4, ajv@^6.5.5:
+ajv@^6.1.0, ajv@^6.11.0, ajv@^6.12.2, ajv@^6.5.5:
   version "6.12.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.4.tgz#0614facc4522127fa713445c6bfd3ebd376e2234"
   integrity sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==
+  dependencies:
+    fast-deep-equal "^3.1.1"
+    fast-json-stable-stringify "^2.0.0"
+    json-schema-traverse "^0.4.1"
+    uri-js "^4.2.2"
+
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.4:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -3481,11 +3571,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 ansi-styles@^4.0.0, ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 any-promise@^1.0.0:
@@ -3509,13 +3598,13 @@ anymatch@^3.0.3, anymatch@~3.1.1:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
 
-apollo-cache-control@^0.11.1:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.11.1.tgz#3bce0924ae7322a8b9f7ca1e2fb036d1fc9f1df5"
-  integrity sha512-6iHa8TkcKt4rx5SKRzDNjUIpCQX+7/FlZwD7vRh9JDnM4VH8SWhpj8fUR3CiEY8Kuc4ChXnOY8bCcMju5KPnIQ==
+apollo-cache-control@^0.11.1, apollo-cache-control@^0.11.3:
+  version "0.11.3"
+  resolved "https://registry.yarnpkg.com/apollo-cache-control/-/apollo-cache-control-0.11.3.tgz#caa409692bccc35da582cb133c023c0175b84e91"
+  integrity sha512-21GCeC9AIIa22uD0Vtqn/N0D5kOB4rY/Pa9aQhxVeLN+4f8Eu4nmteXhFypUD0LL1/58dmm8lS5embsfoIGjEA==
   dependencies:
     apollo-server-env "^2.4.5"
-    apollo-server-plugin-base "^0.9.1"
+    apollo-server-plugin-base "^0.10.1"
 
 apollo-datasource@^0.7.2:
   version "0.7.2"
@@ -3573,6 +3662,14 @@ apollo-graphql@^0.5.0:
     apollo-env "^0.6.5"
     lodash.sortby "^4.7.0"
 
+apollo-graphql@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/apollo-graphql/-/apollo-graphql-0.6.0.tgz#37bee7dc853213269137f4c60bfdf2ee28658669"
+  integrity sha512-BxTf5LOQe649e9BNTPdyCGItVv4Ll8wZ2BKnmiYpRAocYEXAVrQPWuSr3dO4iipqAU8X0gvle/Xu9mSqg5b7Qg==
+  dependencies:
+    apollo-env "^0.6.5"
+    lodash.sortby "^4.7.0"
+
 apollo-link@1.2.14, apollo-link@^1.2.14:
   version "1.2.14"
   resolved "https://registry.yarnpkg.com/apollo-link/-/apollo-link-1.2.14.tgz#3feda4b47f9ebba7f4160bef8b977ba725b684d9"
@@ -3582,6 +3679,13 @@ apollo-link@1.2.14, apollo-link@^1.2.14:
     ts-invariant "^0.4.0"
     tslib "^1.9.3"
     zen-observable-ts "^0.8.21"
+
+apollo-reporting-protobuf@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/apollo-reporting-protobuf/-/apollo-reporting-protobuf-0.6.0.tgz#179e49e99229851d588b1fe6faff4ffdcf503224"
+  integrity sha512-AFLQIuO0QhkoCF+41Be/B/YU0C33BZ0opfyXorIjM3MNNiEDSyjZqmUozlB3LqgfhT9mn2IR5RSsA+1b4VovDQ==
+  dependencies:
+    "@apollo/protobufjs" "^1.0.3"
 
 apollo-server-caching@^0.5.2:
   version "0.5.2"
@@ -3618,7 +3722,7 @@ apollo-server-core@2.16.1:
     subscriptions-transport-ws "^0.9.11"
     ws "^6.0.0"
 
-apollo-server-core@^2.15.1, apollo-server-core@^2.17.0:
+apollo-server-core@^2.15.1:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.17.0.tgz#6af697ffe4968e74add01cd1efd2a8fb33299cf3"
   integrity sha512-rjAkBbKSrGLDfg/g5bohnPlQahmkAxgEBuMDVsoF3aa+RaEPXPUMYrLbOxntl0LWeLbPiMa/IyFF43dvlGqV7w==
@@ -3646,6 +3750,38 @@ apollo-server-core@^2.15.1, apollo-server-core@^2.17.0:
     subscriptions-transport-ws "^0.9.11"
     ws "^6.0.0"
 
+apollo-server-core@^2.17.0, apollo-server-core@^2.18.2:
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-core/-/apollo-server-core-2.18.2.tgz#1b8a625531a92e137f68c730bc42b9e3f7d7fcbb"
+  integrity sha512-phz57BFBukMa3Ta7ZVW7pj1pdUne9KYLbcBdEcITr+I0+nbhy+YM8gcgpOnjrokWYiEZgIe52XeM3m4BMLw5dg==
+  dependencies:
+    "@apollographql/apollo-tools" "^0.4.3"
+    "@apollographql/graphql-playground-html" "1.6.26"
+    "@types/graphql-upload" "^8.0.0"
+    "@types/ws" "^7.0.0"
+    apollo-cache-control "^0.11.3"
+    apollo-datasource "^0.7.2"
+    apollo-graphql "^0.6.0"
+    apollo-reporting-protobuf "^0.6.0"
+    apollo-server-caching "^0.5.2"
+    apollo-server-env "^2.4.5"
+    apollo-server-errors "^2.4.2"
+    apollo-server-plugin-base "^0.10.1"
+    apollo-server-types "^0.6.0"
+    apollo-tracing "^0.11.4"
+    async-retry "^1.2.1"
+    fast-json-stable-stringify "^2.0.0"
+    graphql-extensions "^0.12.5"
+    graphql-tag "^2.9.2"
+    graphql-tools "^4.0.0"
+    graphql-upload "^8.0.2"
+    loglevel "^1.6.7"
+    lru-cache "^5.0.0"
+    sha.js "^2.4.11"
+    subscriptions-transport-ws "^0.9.11"
+    uuid "^8.0.0"
+    ws "^6.0.0"
+
 apollo-server-env@^2.4.5:
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/apollo-server-env/-/apollo-server-env-2.4.5.tgz#73730b4f0439094a2272a9d0caa4079d4b661d5f"
@@ -3659,7 +3795,7 @@ apollo-server-errors@^2.4.2:
   resolved "https://registry.yarnpkg.com/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz#1128738a1d14da989f58420896d70524784eabe5"
   integrity sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==
 
-apollo-server-express@2.17.0, apollo-server-express@^2.0.0:
+apollo-server-express@2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.17.0.tgz#2014559b75a0bcf7ff8cf0f2d077da6653abbc18"
   integrity sha512-PonpWOuM1DH3Cz0bu56Tusr3GXOnectC6AD/gy2GXK0v84E7tKTuxEY3SgsgxhvfvvhfwJbXTyIogL/wezqnCw==
@@ -3681,7 +3817,30 @@ apollo-server-express@2.17.0, apollo-server-express@^2.0.0:
     subscriptions-transport-ws "^0.9.16"
     type-is "^1.6.16"
 
-apollo-server-fastify@2.17.0, apollo-server-fastify@^2.16.0:
+apollo-server-express@^2.0.0:
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-express/-/apollo-server-express-2.18.2.tgz#eb5f1ba566268080dd56269d9a7dfade55ccded8"
+  integrity sha512-9P5YOSE2amcNdkXqxqU3oulp+lpwoIBdwS2vOP69kl6ix+n7vEWHde4ulHwwl4xLdtZ88yyxgdKJEIkhaepiNw==
+  dependencies:
+    "@apollographql/graphql-playground-html" "1.6.26"
+    "@types/accepts" "^1.3.5"
+    "@types/body-parser" "1.19.0"
+    "@types/cors" "2.8.7"
+    "@types/express" "4.17.7"
+    "@types/express-serve-static-core" "4.17.9"
+    accepts "^1.3.5"
+    apollo-server-core "^2.18.2"
+    apollo-server-types "^0.6.0"
+    body-parser "^1.18.3"
+    cors "^2.8.4"
+    express "^4.17.1"
+    graphql-subscriptions "^1.0.0"
+    graphql-tools "^4.0.0"
+    parseurl "^1.3.2"
+    subscriptions-transport-ws "^0.9.16"
+    type-is "^1.6.16"
+
+apollo-server-fastify@2.17.0:
   version "2.17.0"
   resolved "https://registry.yarnpkg.com/apollo-server-fastify/-/apollo-server-fastify-2.17.0.tgz#25bd1444eb050bb0e1d3c053417fd39bfeb970b1"
   integrity sha512-q2DFlXTB7cI4J8X3xyNKfa2H68yyUN/V1T+9WsPESg/HjQ5IJvtk0yrg/uQ9DYi+KGo/i9zcv9xpqpSJGiuDRQ==
@@ -3693,6 +3852,26 @@ apollo-server-fastify@2.17.0, apollo-server-fastify@^2.16.0:
     fastify-cors "^0.2.0"
     graphql-subscriptions "^1.0.0"
     graphql-tools "^4.0.0"
+
+apollo-server-fastify@^2.16.0:
+  version "2.18.2"
+  resolved "https://registry.yarnpkg.com/apollo-server-fastify/-/apollo-server-fastify-2.18.2.tgz#3d2c3736cead664b922d2364028270fd3bca2f7f"
+  integrity sha512-RVFke3EHUsfeHPQWWRpUwl9jyKpHHwSe4+htqSn59CoRzQJ/qtqZAy3dfLH4r3CkeNixdnLyRsoCK1E4+70weg==
+  dependencies:
+    "@apollographql/graphql-playground-html" "1.6.26"
+    apollo-server-core "^2.18.2"
+    apollo-server-types "^0.6.0"
+    fastify-accepts "^1.0.0"
+    fastify-cors "^0.2.0"
+    graphql-subscriptions "^1.0.0"
+    graphql-tools "^4.0.0"
+
+apollo-server-plugin-base@^0.10.1:
+  version "0.10.1"
+  resolved "https://registry.yarnpkg.com/apollo-server-plugin-base/-/apollo-server-plugin-base-0.10.1.tgz#b053d43b1ff5f728735ed35095cf4427657bfa9f"
+  integrity sha512-XChCBDNyfByWqVXptsjPwrwrCj5cxMmNbchZZi8KXjtJ0hN2C/9BMNlInJd6bVGXvUbkRJYUakfKCfO5dZmwIg==
+  dependencies:
+    apollo-server-types "^0.6.0"
 
 apollo-server-plugin-base@^0.9.1:
   version "0.9.1"
@@ -3710,6 +3889,15 @@ apollo-server-types@^0.5.1:
     apollo-server-caching "^0.5.2"
     apollo-server-env "^2.4.5"
 
+apollo-server-types@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/apollo-server-types/-/apollo-server-types-0.6.0.tgz#6085f8389881b79911384dab6c0e8a8b91c0e1a2"
+  integrity sha512-usqXaz81bHxD2IZvKEQNnLpSbf2Z/BmobXZAjEefJEQv1ItNn+lJNUmSSEfGejHvHlg2A7WuAJKJWyDWcJrNnA==
+  dependencies:
+    apollo-reporting-protobuf "^0.6.0"
+    apollo-server-caching "^0.5.2"
+    apollo-server-env "^2.4.5"
+
 apollo-tracing@^0.11.1:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.11.1.tgz#3e3a4ce4b21e57dcc57b10bbd539db243b752606"
@@ -3718,13 +3906,13 @@ apollo-tracing@^0.11.1:
     apollo-server-env "^2.4.5"
     apollo-server-plugin-base "^0.9.1"
 
-apollo-tracing@^0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.11.2.tgz#14308b176e021f5e6ec3ee670f8f96e9fbfdb50c"
-  integrity sha512-QjmRd2ozGD+PfmF6U9w/w6jrclYSBNczN6Bzppr8qA5somEGl5pqdprIZYL28H0IapZiutA3x6p6ZVF/cVX8wA==
+apollo-tracing@^0.11.2, apollo-tracing@^0.11.4:
+  version "0.11.4"
+  resolved "https://registry.yarnpkg.com/apollo-tracing/-/apollo-tracing-0.11.4.tgz#e953547064bc50dfa337cbe56836271bfd2d2efc"
+  integrity sha512-zBu/SwQlXfbdpcKLzWARGVjrEkIZUW3W9Mb4CCIzv07HbBQ8IQpmf9w7HIJJefC7rBiBJYg6JBGyuro3N2lxCA==
   dependencies:
     apollo-server-env "^2.4.5"
-    apollo-server-plugin-base "^0.9.1"
+    apollo-server-plugin-base "^0.10.1"
 
 apollo-upload-client@14.1.2:
   version "14.1.2"
@@ -5613,7 +5801,7 @@ debug@3.1.0, debug@=3.1.0, debug@~3.1.0:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1, debug@~4.1.0:
+debug@4, debug@^4.0.0, debug@~4.1.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
   integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
@@ -5626,6 +5814,13 @@ debug@^3.1.0, debug@^3.2.6:
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
   dependencies:
     ms "^2.1.1"
+
+debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
+  integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
+  dependencies:
+    ms "2.1.2"
 
 debuglog@^1.0.1:
   version "1.0.1"
@@ -5682,7 +5877,7 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -6057,20 +6252,38 @@ error-ex@^1.2.0, error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
-  version "1.17.6"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.6.tgz#9142071707857b2cacc7b89ecb670316c3e2d52a"
-  integrity sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==
+es-abstract@^1.17.0-next.1, es-abstract@^1.17.2:
+  version "1.17.7"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.7.tgz#a4de61b2f66989fc7421676c1cb9787573ace54c"
+  integrity sha512-VBl/gnfcJ7OercKA9MVaegWsBHFjV492syMudcnQZvt/Dw8ezpcOHYZXa/J96O8vx+g4x65YKhxOwDUh63aS5g==
   dependencies:
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
     has "^1.0.3"
     has-symbols "^1.0.1"
-    is-callable "^1.2.0"
-    is-regex "^1.1.0"
-    object-inspect "^1.7.0"
+    is-callable "^1.2.2"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
     object-keys "^1.1.1"
-    object.assign "^4.1.0"
+    object.assign "^4.1.1"
+    string.prototype.trimend "^1.0.1"
+    string.prototype.trimstart "^1.0.1"
+
+es-abstract@^1.18.0-next.0, es-abstract@^1.18.0-next.1:
+  version "1.18.0-next.1"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
+  integrity sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
+  dependencies:
+    es-to-primitive "^1.2.1"
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
+    is-callable "^1.2.2"
+    is-negative-zero "^2.0.0"
+    is-regex "^1.1.1"
+    object-inspect "^1.8.0"
+    object-keys "^1.1.1"
+    object.assign "^4.1.1"
     string.prototype.trimend "^1.0.1"
     string.prototype.trimstart "^1.0.1"
 
@@ -6242,12 +6455,12 @@ eslint-visitor-keys@^2.0.0:
   integrity sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
 
 eslint@^7.4.0:
-  version "7.11.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.11.0.tgz#aaf2d23a0b5f1d652a08edacea0c19f7fadc0b3b"
-  integrity sha512-G9+qtYVCHaDi1ZuWzBsOWo2wSwd70TXnU6UHA3cTYHp7gCTXZcpggWFoUVAMRarg68qtPoNfFbzPh+VdOgmwmw==
+  version "7.12.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-7.12.0.tgz#7b6a85f87a9adc239e979bb721cde5ce0dc27da6"
+  integrity sha512-n5pEU27DRxCSlOhJ2rO57GDLcNsxO0LPpAbpFdh7xmcDmjmlGUfoyrsB3I7yYdQXO5N3gkSTiDrPSPNFiiirXA==
   dependencies:
     "@babel/code-frame" "^7.0.0"
-    "@eslint/eslintrc" "^0.1.3"
+    "@eslint/eslintrc" "^0.2.0"
     ajv "^6.10.0"
     chalk "^4.0.0"
     cross-spawn "^7.0.2"
@@ -7375,14 +7588,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql-extensions@^0.12.4:
-  version "0.12.4"
-  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.12.4.tgz#c0aa49a20f983a2da641526d1e505996bd2b4188"
-  integrity sha512-GnR4LiWk3s2bGOqIh6V1JgnSXw2RCH4NOgbCFEWvB6JqWHXTlXnLZ8bRSkCiD4pltv7RHUPWqN/sGh8R6Ae/ag==
+graphql-extensions@^0.12.4, graphql-extensions@^0.12.5:
+  version "0.12.5"
+  resolved "https://registry.yarnpkg.com/graphql-extensions/-/graphql-extensions-0.12.5.tgz#b0e6b218f26f5aafe9dd73642410fec6beac0575"
+  integrity sha512-mGyGaktGpK3TVBtM0ZoyPX6Xk0mN9GYX9DRyFzDU4k4A2w93nLX7Ebcp+9/O5nHRmgrc0WziYYSmoWq2WNIoUQ==
   dependencies:
     "@apollographql/apollo-tools" "^0.4.3"
     apollo-server-env "^2.4.5"
-    apollo-server-types "^0.5.1"
+    apollo-server-types "^0.6.0"
 
 graphql-subscriptions@^1.0.0:
   version "1.1.0"
@@ -7408,33 +7621,32 @@ graphql-tools@^4.0.0:
     uuid "^3.1.0"
 
 graphql-tools@^6.0.13, graphql-tools@^6.0.14:
-  version "6.2.5"
-  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-6.2.5.tgz#53c0b5e39189a70a1aae242474af800b865c9839"
-  integrity sha512-pKwJ9rN6uFZp+3Jfapxw3FqWNbaPyYzS3wtv9CkdOS5HHT4uixI2+k+J5YVMINESqbTRMYNuGsbFs4ZuNDLPjg==
+  version "6.2.6"
+  resolved "https://registry.yarnpkg.com/graphql-tools/-/graphql-tools-6.2.6.tgz#557c6d32797a02988f214bd596dec2abd12425dd"
+  integrity sha512-OyhSvK5ALVVD6bFiWjAqv2+lRyvjIRfb6Br5Tkjrv++rxnXDodPH/zhMbDGRw+W3SD5ioGEEz84yO48iPiN7jA==
   dependencies:
-    "@graphql-tools/batch-delegate" "^6.2.5"
-    "@graphql-tools/batch-execute" "^7.0.0"
-    "@graphql-tools/code-file-loader" "^6.2.5"
-    "@graphql-tools/delegate" "^7.0.0"
-    "@graphql-tools/git-loader" "^6.2.5"
-    "@graphql-tools/github-loader" "^6.2.5"
-    "@graphql-tools/graphql-file-loader" "^6.2.5"
-    "@graphql-tools/graphql-tag-pluck" "^6.2.6"
+    "@graphql-tools/batch-delegate" "^6.2.6"
+    "@graphql-tools/code-file-loader" "^6.2.4"
+    "@graphql-tools/delegate" "^6.2.4"
+    "@graphql-tools/git-loader" "^6.2.4"
+    "@graphql-tools/github-loader" "^6.2.4"
+    "@graphql-tools/graphql-file-loader" "^6.2.4"
+    "@graphql-tools/graphql-tag-pluck" "^6.2.4"
     "@graphql-tools/import" "^6.2.4"
-    "@graphql-tools/json-file-loader" "^6.2.5"
-    "@graphql-tools/links" "^6.2.5"
-    "@graphql-tools/load" "^6.2.5"
+    "@graphql-tools/json-file-loader" "^6.2.4"
+    "@graphql-tools/links" "^6.2.4"
+    "@graphql-tools/load" "^6.2.4"
     "@graphql-tools/load-files" "^6.2.4"
-    "@graphql-tools/merge" "^6.2.5"
-    "@graphql-tools/mock" "^7.0.0"
-    "@graphql-tools/module-loader" "^6.2.5"
-    "@graphql-tools/relay-operation-optimizer" "^6.2.5"
-    "@graphql-tools/resolvers-composition" "^6.2.5"
-    "@graphql-tools/schema" "^7.0.0"
-    "@graphql-tools/stitch" "^7.0.0"
-    "@graphql-tools/url-loader" "^6.3.1"
-    "@graphql-tools/utils" "^7.0.0"
-    "@graphql-tools/wrap" "^7.0.0"
+    "@graphql-tools/merge" "^6.2.4"
+    "@graphql-tools/mock" "^6.2.4"
+    "@graphql-tools/module-loader" "^6.2.4"
+    "@graphql-tools/relay-operation-optimizer" "^6.2.4"
+    "@graphql-tools/resolvers-composition" "^6.2.4"
+    "@graphql-tools/schema" "^6.2.4"
+    "@graphql-tools/stitch" "^6.2.4"
+    "@graphql-tools/url-loader" "^6.2.4"
+    "@graphql-tools/utils" "^6.2.4"
+    "@graphql-tools/wrap" "^6.2.4"
     tslib "~2.0.1"
 
 graphql-upload@^8.0.2:
@@ -7446,13 +7658,6 @@ graphql-upload@^8.0.2:
     fs-capacitor "^2.0.4"
     http-errors "^1.7.3"
     object-path "^0.11.4"
-
-graphql@^14.5.3:
-  version "14.7.0"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
-  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
-  dependencies:
-    iterall "^1.2.2"
 
 graphql@^15.3.0:
   version "15.3.0"
@@ -7528,7 +7733,7 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
+has-symbols@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
   integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
@@ -8077,10 +8282,10 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.4, is-callable@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.0.tgz#83336560b54a38e35e3a2df7afd0454d691468bb"
-  integrity sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==
+is-callable@^1.1.4, is-callable@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
+  integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -8216,6 +8421,11 @@ is-negated-glob@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-negated-glob/-/is-negated-glob-1.0.0.tgz#6910bca5da8c95e784b5751b976cf5a10fee36d2"
   integrity sha1-aRC8pdqMleeEtXUbl2z1oQ/uNtI=
 
+is-negative-zero@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
+  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -8270,7 +8480,7 @@ is-promise@^2.1:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
-is-regex@^1.1.0:
+is-regex@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
   integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
@@ -8445,7 +8655,7 @@ iterall@1.2.2:
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
 
-iterall@^1.1.3, iterall@^1.2.1, iterall@^1.2.2:
+iterall@^1.1.3, iterall@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
   integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
@@ -8507,17 +8717,7 @@ jest-config@^26.6.1:
     micromatch "^4.0.2"
     pretty-format "^26.6.1"
 
-jest-diff@^26.0.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.0.tgz#5e5bbbaf93ec5017fae2b3ef12fc895e29988379"
-  integrity sha512-IH09rKsdWY8YEY7ii2BHlSq59oXyF2pK3GoK+hOK9eD/x6009eNB5Jv1shLMKgxekodPzLlV7eZP1jPFQYds8w==
-  dependencies:
-    chalk "^4.0.0"
-    diff-sequences "^26.5.0"
-    jest-get-type "^26.3.0"
-    pretty-format "^26.6.0"
-
-jest-diff@^26.6.1:
+jest-diff@^26.0.0, jest-diff@^26.6.1:
   version "26.6.1"
   resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.1.tgz#38aa194979f454619bb39bdee299fb64ede5300c"
   integrity sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==
@@ -8782,19 +8982,7 @@ jest-snapshot@^26.6.1:
     pretty-format "^26.6.1"
     semver "^7.3.2"
 
-jest-util@^26.1.0:
-  version "26.3.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.3.0.tgz#a8974b191df30e2bf523ebbfdbaeb8efca535b3e"
-  integrity sha512-4zpn6bwV0+AMFN0IYhH/wnzIQzRaYVrz1A8sYnRnj4UXDXbOVtWmlaZkO9mipFqZ13okIfN87aDoJWB7VH6hcw==
-  dependencies:
-    "@jest/types" "^26.3.0"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    graceful-fs "^4.2.4"
-    is-ci "^2.0.0"
-    micromatch "^4.0.2"
-
-jest-util@^26.6.1:
+jest-util@^26.1.0, jest-util@^26.6.1:
   version "26.6.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-26.6.1.tgz#4cc0d09ec57f28d12d053887eec5dc976a352e9b"
   integrity sha512-xCLZUqVoqhquyPLuDXmH7ogceGctbW8SMyQVjD9o+1+NPWI7t0vO08udcFLVPLgKWcvc+zotaUv/RuaR6l8HIA==
@@ -9951,7 +10139,7 @@ ms@2.1.1:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
   integrity sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==
 
-ms@^2.0.0, ms@^2.1.1:
+ms@2.1.2, ms@^2.0.0, ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -10122,7 +10310,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@2.6.1:
+node-fetch@2.6.1, node-fetch@^2.1.2, node-fetch@^2.2.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
@@ -10135,7 +10323,7 @@ node-fetch@^1.0.1:
     encoding "^0.1.11"
     is-stream "^1.0.1"
 
-node-fetch@^2.1.2, node-fetch@^2.2.0, node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.0.tgz#e633456386d4aa55863f676a7ab0daa8fdecb0fd"
   integrity sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==
@@ -10391,20 +10579,20 @@ object-hash@2.0.3:
   resolved "https://registry.yarnpkg.com/object-hash/-/object-hash-2.0.3.tgz#d12db044e03cd2ca3d77c0570d87225b02e1e6ea"
   integrity sha512-JPKn0GMu+Fa3zt3Bmr66JhokJU5BaNBIh4ZeTlaCBzrBsOeXzwcKKAK1tbLiPKgvwmPXsDvvLHoWh5Bm7ofIYg==
 
-object-inspect@^1.7.0:
+object-inspect@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
   integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
 
 object-path@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.4.tgz#370ae752fbf37de3ea70a861c23bba8915691949"
-  integrity sha1-NwrnUvvzfePqcKhhwju6iRVpGUk=
+  version "0.11.5"
+  resolved "https://registry.yarnpkg.com/object-path/-/object-path-0.11.5.tgz#d4e3cf19601a5140a55a16ad712019a9c50b577a"
+  integrity sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg==
 
 object-visit@^1.0.0:
   version "1.0.1"
@@ -10413,15 +10601,15 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+object.assign@^4.1.0, object.assign@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
+  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.0"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
 
 object.getownpropertydescriptors@^2.0.3, object.getownpropertydescriptors@^2.1.0:
   version "2.1.0"
@@ -10488,10 +10676,10 @@ opencollective-postinstall@^2.0.2:
   resolved "https://registry.yarnpkg.com/opencollective-postinstall/-/opencollective-postinstall-2.0.3.tgz#7a0fff978f6dbfa4d006238fbac98ed4198c3259"
   integrity sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
 
-optimism@^0.12.1:
-  version "0.12.1"
-  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.12.1.tgz#933f9467b9aef0e601655adb9638f893e486ad02"
-  integrity sha512-t8I7HM1dw0SECitBYAqFOVHoBAHEQBTeKjIL9y9ImHzAVkdyPK4ifTgM4VJRDtTUY4r/u5Eqxs4XcGPHaoPkeQ==
+optimism@^0.13.0:
+  version "0.13.0"
+  resolved "https://registry.yarnpkg.com/optimism/-/optimism-0.13.0.tgz#c08904e1439a0eb9e7f86183dafa06cc715ff351"
+  integrity sha512-6JAh3dH+YUE4QUdsgUw8nUQyrNeBKfAEKOHMlLkQ168KhIYFIxzPsHakWrRXDnTO+x61RJrS3/2uEt6W0xlocA==
   dependencies:
     "@wry/context" "^0.5.2"
 
@@ -11059,17 +11247,7 @@ prettier@^2.0.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
   integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
 
-pretty-format@^26.0.0, pretty-format@^26.6.0:
-  version "26.6.0"
-  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.0.tgz#1e1030e3c70e3ac1c568a5fd15627671ea159391"
-  integrity sha512-Uumr9URVB7bm6SbaByXtx+zGlS+0loDkFMHP0kHahMjmfCtmFY03iqd++5v3Ld6iB5TocVXlBN/T+DXMn9d4BA==
-  dependencies:
-    "@jest/types" "^26.6.0"
-    ansi-regex "^5.0.0"
-    ansi-styles "^4.0.0"
-    react-is "^16.12.0"
-
-pretty-format@^26.6.1:
+pretty-format@^26.0.0, pretty-format@^26.6.1:
   version "26.6.1"
   resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.1.tgz#af9a2f63493a856acddeeb11ba6bcf61989660a8"
   integrity sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==
@@ -11349,7 +11527,7 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1:
+react-is@^16.7.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
@@ -11749,14 +11927,14 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.10.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
   dependencies:
     path-parse "^1.0.6"
 
-resolve@^1.18.1:
+resolve@^1.18.1, resolve@^1.3.2:
   version "1.18.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.18.1.tgz#018fcb2c5b207d2a6424aee361c5a266da8f4130"
   integrity sha512-lDfCPaMKfOJXjy0dPayzPdF1phampNWr3qFCjAu+rw/qbQmr5jWH5xN2hwh9QKfw9E5v4hwV7A+jrCmL8yjjqA==
@@ -12594,20 +12772,20 @@ string-width@^4.1.0, string-width@^4.2.0:
     strip-ansi "^6.0.0"
 
 string.prototype.trimend@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
-  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz#6ddd9a8796bc714b489a3ae22246a208f37bfa46"
+  integrity sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==
   dependencies:
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
+    es-abstract "^1.18.0-next.1"
 
 string.prototype.trimstart@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
-  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz#22d45da81015309cd0cdd79787e8919fc5c613e7"
+  integrity sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==
   dependencies:
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
+    es-abstract "^1.18.0-next.1"
 
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
@@ -12781,9 +12959,9 @@ symbol-observable@1.2.0, symbol-observable@^1.0.4:
   integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-observable@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.1.tgz#ce66c36a04ed0f3056e7293184749a6fdd7063ea"
-  integrity sha512-QrfHrrEUMadQCgMijc3YpfA4ncwgqGv58Xgvdu3JZVQB7iY7cAkiqobZEZbaA863jof8AdpR01CPnZ5UWeqZBQ==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-2.0.3.tgz#5b521d3d07a43c351055fa43b8355b62d33fd16a"
+  integrity sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==
 
 symbol-tree@^3.2.4:
   version "3.2.4"
@@ -12887,15 +13065,6 @@ terser@^4.1.2:
   version "4.8.0"
   resolved "https://registry.yarnpkg.com/terser/-/terser-4.8.0.tgz#63056343d7c70bb29f3af665865a46fe03a0df17"
   integrity sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==
-  dependencies:
-    commander "^2.20.0"
-    source-map "~0.6.1"
-    source-map-support "~0.5.12"
-
-terser@^5.2.0:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/terser/-/terser-5.3.1.tgz#f50fe20ab48b15234fe9bdd86b10148ad5fca787"
-  integrity sha512-yD80f4hdwCWTH5mojzxe1q8bN1oJbsK/vfJGLcPZM/fl+/jItIVNKhFIHqqR71OipFWMLgj3Kc+GIp6CeIqfnA==
   dependencies:
     commander "^2.20.0"
     source-map "~0.6.1"
@@ -13134,10 +13303,11 @@ ts-invariant@^0.4.0, ts-invariant@^0.4.4:
     tslib "^1.9.3"
 
 ts-jest@^26.1.3:
-  version "26.4.1"
-  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.1.tgz#08ec0d3fc2c3a39e4a46eae5610b69fafa6babd0"
-  integrity sha512-F4aFq01aS6mnAAa0DljNmKr/Kk9y4HVZ1m6/rtJ0ED56cuxINGq3Q9eVAh+z5vcYKe5qnTMvv90vE8vUMFxomg==
+  version "26.4.2"
+  resolved "https://registry.yarnpkg.com/ts-jest/-/ts-jest-26.4.2.tgz#00b6c970bee202ceef7c6e6e9805c4837b22dab8"
+  integrity sha512-0+MynTTzzbuy5rGjzsCKjxHJk5gY906c/FSaqQ3081+G7dp2Yygfa9hVlbrtNNcztffh1mC6Rs9jb/yHpcjsoQ==
   dependencies:
+    "@jest/create-cache-key-function" "^26.5.0"
     "@types/jest" "26.x"
     bs-logger "0.x"
     buffer-from "1.x"
@@ -13151,9 +13321,9 @@ ts-jest@^26.1.3:
     yargs-parser "20.x"
 
 ts-loader@^8.0.1:
-  version "8.0.6"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.6.tgz#8f47d203ef8fc95826a292a09f97a02bf1f57565"
-  integrity sha512-c8XkRbhKxFLbiIwZR7FBGWDq0MIz/QSpx3CGpj0abJxD5YVX8oDhQkJLeGbXUPRIlaX4Ajmr77fOiFVZ3gSU7g==
+  version "8.0.7"
+  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-8.0.7.tgz#9ce70db5b3906cc9143a09c54ff5247d102ea974"
+  integrity sha512-ooa4wxlZ9TOXaJ/iVyZlWsim79Ul4KyifSwyT2hOrbQA6NZJypsLOE198o8Ko+JV+ZHnMArvWcl4AnRqpCU/Mw==
   dependencies:
     chalk "^2.3.0"
     enhanced-resolve "^4.0.0"
@@ -13207,15 +13377,25 @@ tsconfig-paths@3.9.0, tsconfig-paths@^3.4.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@2.0.1, tslib@~2.0.0, tslib@~2.0.1:
+tslib@2.0.1, tslib@~2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.1.tgz#410eb0d113e5b6356490eec749603725b021b43e"
   integrity sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ==
 
-tslib@^1.10.0, tslib@^1.8.1, tslib@^1.9.0, tslib@^1.9.3:
+tslib@^1.10.0, tslib@^1.9.3:
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^1.8.1, tslib@^1.9.0:
   version "1.13.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.13.0.tgz#c881e13cc7015894ed914862d276436fa9a47043"
   integrity sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==
+
+tslib@~2.0.1:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.0.3.tgz#8e0741ac45fc0c226e58a17bfc3e64b9bc6ca61c"
+  integrity sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ==
 
 tsutils@^3.17.1:
   version "3.17.1"
@@ -13331,9 +13511,9 @@ typescript@^4.0.2, typescript@~4.0.2:
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
 
 ua-parser-js@^0.7.18:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
+  version "0.7.22"
+  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.22.tgz#960df60a5f911ea8f1c818f3747b99c6e177eae3"
+  integrity sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q==
 
 uglify-js@^3.1.4:
   version "3.10.0"
@@ -13515,7 +13695,7 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
-uuid@8.3.0, uuid@^8.0.0, uuid@^8.3.0:
+uuid@8.3.0, uuid@^8.3.0:
   version "8.3.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.0.tgz#ab738085ca22dc9a8c92725e459b1d507df5d6ea"
   integrity sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ==
@@ -13524,6 +13704,11 @@ uuid@^3.0.1, uuid@^3.1.0, uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+
+uuid@^8.0.0:
+  version "8.3.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.1.tgz#2ba2e6ca000da60fce5a196954ab241131e05a31"
+  integrity sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==
 
 v8-compile-cache@^2.0.3:
   version "2.1.1"
@@ -13993,9 +14178,9 @@ yaml@^1.10.0, yaml@^1.7.2:
   integrity sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
 
 yargs-parser@20.x:
-  version "20.2.0"
-  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.0.tgz#944791ca2be2e08ddadd3d87e9de4c6484338605"
-  integrity sha512-2agPoRFPoIcFzOIp6656gcvsg2ohtscpw2OINr/q46+Sq41xz2OYLqx5HRHabmFU1OARIPAYH5uteICE7mn/5A==
+  version "20.2.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.3.tgz#92419ba867b858c868acf8bae9bf74af0dd0ce26"
+  integrity sha512-emOFRT9WVHw03QSvN5qor9QQT9+sw5vwxfYweivSMHTcAXPefwVae2FjO7JJjj8hCE4CzPOPeFM83VwT29HCww==
 
 yargs-parser@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
The log methods now accept an object instead of multiple parameters to allow for the passing of
extra keys. These keys can be anything, from cloud-provider to anything else you want to add.
There's also a lot of refactoring and making some new interfaces for cleaner passing of parameters

BREAKING CHANGE: log methods now take an object as the second parameter instead of having 3 extra
optional parameters
    
fix #215 #228 #297