### PR TITLE
feat(logger): allow for object values to be masked

### DIFF
--- a/.changeset/pink-schools-dress.md
+++ b/.changeset/pink-schools-dress.md
@@ -1,0 +1,21 @@
+---
+'@ogma/logger': minor
+---
+
+Adds the ability to mask values of an object while logging based on an initial array config
+
+A `masks` property can now be passed to the `Ogma` constructor. This property is an array, and will be checked against the keys of an object that Ogma is logging. If the key matches a value in the array, Ogma will replace the value with a string of asterisks (`*`) matching the length of the original string.
+
+e.g.
+
+```
+ogma.log({ password: '12345' })
+```
+
+will log the object
+
+```
+{
+  password: '*****'
+}
+```

--- a/apps/docs/docs/introduction.md
+++ b/apps/docs/docs/introduction.md
@@ -24,15 +24,16 @@ So it was mentioned that Ogma beats out Winston and Bunyan and comes very close 
 
 Benchmarks were made by testing the logging capabilities of several loggers against each other. All loggers are writing to a writeStream of `/dev/null`. Each logger writes 100000 logs of each log type. Simple is a small string. JSON is a simple json, one key one value. Long is a 2000 random byte string. Deep is a deep JSON, including using the `globalThis`. All timings were made by using the `perf_hooks` module.
 
-| Logger | Simple | Long | JSON | Deep |
-| --- | --- | --- | --- | --- |
-| Bunyan | 355.005893ms | 4099.797733ms | 410.885866ms | 2266.010139ms |
-| Ogma | 172.904867ms | 1847.369098ms | 310.955876ms | 445.961304ms |
-| Pino | 116.647594ms | 4287.163808ms | 141.358471ms | 1355.486535ms |
-| Winston | 380.9764ms | 5127.20654ms | 353.4015ms | 457.380278ms |
+| Logger    | Simple  | Long     | JSON    | Deep     |
+| --------- | ------- | -------- | ------- | -------- |
+| Bunyan    | 383.3ms | 4037.3ms | 411.5ms | 2000.3ms |
+| Ogma      | 177.0ms | 1790.2ms | 338.0ms | 467.4ms  |
+| OgmaMasks | 171.2ms | 1846.6ms | 315.1ms | 695.4ms  |
+| Pino      | 126.6ms | 4056.8ms | 470.4ms | 1385.1ms |
+| Winston   | 398.4ms | 4724.1ms | 337.3ms | 462.8ms  |
 
 :::info
 
-Benchmarks generated on Linux/linux x64 5.11.0-7614-generic ~Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz (cores/threads): 12
+Benchmarks generated on Linux/linux x64 5.11.0-7620-generic ~Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz (cores/threads): 1
 
 :::

--- a/apps/docs/docs/logger.md
+++ b/apps/docs/docs/logger.md
@@ -65,6 +65,13 @@ Examples can be seen below. The JSON structure follows the same form with log le
 | context | string optional | a context for the Ogma class to work with. |
 | application | string optional | an application name for Ogma to print |
 | levelMap | an object with the above levels as the keys and strings as the vales | a way to provide custom log levels in the event that there are mappings the developer wants to support |
+| masks | string[] | An array of words that should be replaced while logging. useful for sensitive information like passwords. |
+
+:::note
+
+Using `masks` can lead to some performance degradations, due to the need to determine what values to block.
+
+:::
 
 ### Using Files instead of a console
 

--- a/benchmarks/logger/README.md
+++ b/benchmarks/logger/README.md
@@ -4,13 +4,14 @@ Benchmarks were made by testing the logging capabilities of several loggers agai
 
 ## Results
 
-| Logger | Simple | Long | JSON | Deep |
-| --- | --- | --- | --- | --- |
-| Bunyan | 355.005893ms | 4099.797733ms | 410.885866ms | 2266.010139ms |
-| Ogma | 172.904867ms | 1847.369098ms | 310.955876ms | 445.961304ms |
-| Pino | 116.647594ms | 4287.163808ms | 141.358471ms | 1355.486535ms |
-| Winston | 380.9764ms | 5127.20654ms | 353.4015ms | 457.380278ms |
+| Logger    | Simple  | Long     | JSON    | Deep     |
+| --------- | ------- | -------- | ------- | -------- |
+| Bunyan    | 383.3ms | 4037.3ms | 411.5ms | 2000.3ms |
+| Ogma      | 177.0ms | 1790.2ms | 338.0ms | 467.4ms  |
+| OgmaMasks | 171.2ms | 1846.6ms | 315.1ms | 695.4ms  |
+| Pino      | 126.6ms | 4056.8ms | 470.4ms | 1385.1ms |
+| Winston   | 398.4ms | 4724.1ms | 337.3ms | 462.8ms  |
 
 ## Information
 
-Benchmarks generated on Linux/linux x64 5.11.0-7614-generic ~Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz (cores/threads): 12
+Benchmarks generated on Linux/linux x64 5.11.0-7620-generic ~Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz (cores/threads): 12

--- a/benchmarks/logger/src/index.ts
+++ b/benchmarks/logger/src/index.ts
@@ -5,6 +5,7 @@ import { performance, PerformanceObserver } from 'perf_hooks';
 import { writeBenchmarks } from './benchmark-writer';
 import { createBunyanLogger } from './bunyan.logger';
 import { createOgmaLogger } from './ogma.logger';
+import { createOgmaWithMasksLogger } from './omga-with-masks.logger';
 import { createPinoLogger } from './pino.logger';
 import { createWinstonLogger } from './winston.logger';
 
@@ -21,7 +22,7 @@ const deepJSON: Record<string, any> = {
 };
 deepJSON.f = deepJSON;
 
-type LoggerName = 'Ogma' | 'Bunyan' | 'Winston' | 'Pino';
+type LoggerName = 'Ogma' | 'Ogma With Masks' | 'Bunyan' | 'Winston' | 'Pino';
 type LogType = 'simple' | 'json' | 'deep' | 'long';
 type LogResult = {
   [index in LoggerName]: {
@@ -35,10 +36,11 @@ const loggers: Array<{
   name: LoggerName;
   logger: { info: (message: any) => void };
 }> = [
-  { name: 'Bunyan', logger: createBunyanLogger(stream as any) },
-  { name: 'Ogma', logger: createOgmaLogger(stream as any) },
-  { name: 'Pino', logger: createPinoLogger(stream as any) },
-  { name: 'Winston', logger: createWinstonLogger(stream as any) },
+  { name: 'Bunyan', logger: createBunyanLogger(stream) },
+  { name: 'Ogma', logger: createOgmaLogger(stream) },
+  { name: 'Ogma With Masks', logger: createOgmaWithMasksLogger(stream) },
+  { name: 'Pino', logger: createPinoLogger(stream) },
+  { name: 'Winston', logger: createWinstonLogger(stream) },
 ];
 
 function writeLogs(logger: { info: (message: any) => void }, message: any) {
@@ -71,6 +73,7 @@ const obs = new PerformanceObserver((items) => {
   const results: LogResult = {
     Bunyan: {},
     Ogma: {},
+    'Ogma With Masks': {},
     Pino: {},
     Winston: {},
   };

--- a/benchmarks/logger/src/index.ts
+++ b/benchmarks/logger/src/index.ts
@@ -22,7 +22,7 @@ const deepJSON: Record<string, any> = {
 };
 deepJSON.f = deepJSON;
 
-type LoggerName = 'Ogma' | 'Ogma With Masks' | 'Bunyan' | 'Winston' | 'Pino';
+type LoggerName = 'Ogma' | 'OgmaMasks' | 'Bunyan' | 'Winston' | 'Pino';
 type LogType = 'simple' | 'json' | 'deep' | 'long';
 type LogResult = {
   [index in LoggerName]: {
@@ -38,7 +38,7 @@ const loggers: Array<{
 }> = [
   { name: 'Bunyan', logger: createBunyanLogger(stream) },
   { name: 'Ogma', logger: createOgmaLogger(stream) },
-  { name: 'Ogma With Masks', logger: createOgmaWithMasksLogger(stream) },
+  { name: 'OgmaMasks', logger: createOgmaWithMasksLogger(stream) },
   { name: 'Pino', logger: createPinoLogger(stream) },
   { name: 'Winston', logger: createWinstonLogger(stream) },
 ];
@@ -73,13 +73,13 @@ const obs = new PerformanceObserver((items) => {
   const results: LogResult = {
     Bunyan: {},
     Ogma: {},
-    'Ogma With Masks': {},
+    OgmaMasks: {},
     Pino: {},
     Winston: {},
   };
   items.getEntries().forEach((logRes) => {
     const [logName, logType] = logRes.name.split(' ');
-    results[logName][logType] = logRes.duration;
+    results[logName][logType] = logRes.duration.toFixed(1);
   });
   writeBenchmarks(results);
   performance.clearMarks();

--- a/benchmarks/logger/src/omga-with-masks.logger.ts
+++ b/benchmarks/logger/src/omga-with-masks.logger.ts
@@ -6,6 +6,6 @@ export function createOgmaWithMasksLogger(stream: OgmaStream) {
     application: 'Ogma Mask Bench',
     stream,
     logLevel: 'INFO',
-    masks: ['d'],
+    masks: ['d', 'hello'],
   });
 }

--- a/benchmarks/logger/src/omga-with-masks.logger.ts
+++ b/benchmarks/logger/src/omga-with-masks.logger.ts
@@ -1,10 +1,11 @@
 import { OgmaStream } from '@ogma/common';
 import { Ogma } from '@ogma/logger';
 
-export function createOgmaLogger(stream: OgmaStream) {
+export function createOgmaWithMasksLogger(stream: OgmaStream) {
   return new Ogma({
-    application: 'Ogma Bench',
+    application: 'Ogma Mask Bench',
     stream,
     logLevel: 'INFO',
+    masks: ['d'],
   });
 }

--- a/packages/logger/src/interfaces/ogma-options.ts
+++ b/packages/logger/src/interfaces/ogma-options.ts
@@ -87,7 +87,7 @@ export interface OgmaOptions {
    * password=somepassword
    * ```
    *
-   * Use with caution as determining if properties should be restricted does take away from _some_ performance
+   * Use with caution as determining if properties should be restricted may take away from _some_ performance
    */
   masks?: string[];
   [index: string]: any;

--- a/packages/logger/src/interfaces/ogma-options.ts
+++ b/packages/logger/src/interfaces/ogma-options.ts
@@ -59,6 +59,37 @@ export interface OgmaOptions {
    */
   levelMap?: Record<OgmaWritableLevel, string>;
   levelKey?: string;
+  /**
+   * an array of words that should be replaced while logging.  useful for sensitive information like passwords.
+   *
+   * **Note**: Ths will only affect objects that are being logged, not direct string
+   *
+   * e.g.
+   * ```ts
+   * ogma.log({
+   *   username: 'user1',
+   *   password: 'somepassword'
+   * })
+   * ```
+   * Will log
+   * ```
+   * {
+   *   username: 'user1',
+   *   password: '************'
+   * }
+   * ```
+   * While
+   * ```ts
+   * ogma.log('password=somepassword')
+   * ```
+   * will log
+   * ```
+   * password=somepassword
+   * ```
+   *
+   * Use with caution as determining if properties should be restricted does take away from _some_ performance
+   */
+  masks?: string[];
   [index: string]: any;
 }
 
@@ -79,4 +110,5 @@ export const OgmaDefaults: OgmaOptions = {
     INFO: 'INFO',
     FINE: 'FINE',
   },
+  masks: [],
 };

--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -99,6 +99,9 @@ export class Ogma {
         }
         seen.add(value);
       }
+      if (this.options.masks.includes(key)) {
+        return '*'.repeat(value.toString().length);
+      }
       return value;
     };
   }

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -303,4 +303,18 @@ describe('small ogma tests', () => {
       );
     });
   });
+  describe('Censor passed values', () => {
+    it.each`
+      json
+      ${false}
+      ${true}
+    `('should censor the "password" value (json: $json)', ({ json }: { json: boolean }) => {
+      ogma = new Ogma({ json, masks: ['password'] });
+      ogma.log({ username: 'something', password: 'mask this' });
+      expect(stdoutSpy.mock.calls[0][0]).toEqual(
+        expect.stringMatching(/"username":\s?"something",/),
+      );
+      expect(stdoutSpy.mock.calls[0][0]).toEqual(expect.stringMatching(/"password":\s?"\*{9}"/));
+    });
+  });
 });


### PR DESCRIPTION
Adds the ability to mask values of an object while logging based on an initial array config

A `masks` property can now be passed to the `Ogma` constructor. This property is an array, and will be checked against the keys of an object that Ogma is logging. If the key matches a value in the array, Ogma will replace the value with a string of asterisks (`*`) matching the length of the original string.

e.g.

```
ogma.log({ password: '12345' })
```

will log the object

```
{
  password: '*****'
}
```