### PR TITLE
fix: update the peer deps for socket.io package

### DIFF
--- a/.changeset/eight-dolls-smash.md
+++ b/.changeset/eight-dolls-smash.md
@@ -1,0 +1,5 @@
+---
+'@ogma/platform-socket.io': patch
+---
+
+Fix the peer dependencies for socket.io and @nestjs/plaltform-socket.io

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,23 +38,23 @@ jobs:
         uses: changesets/action@master
         with:
           # This expects you to have a script called release which does a build for your packages and calls changeset publish
-          publish: pnpm release
+          publish: sed -i -e "s/'packages/'dist/" pnpm-workspace.yaml && pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-  agent_1:
-    runs-on: ubuntu-latest
-    name: Agent 1
-    timeout-minutes: 60
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
-        with:
-          node-version: 14.x
-      - name: Install pnpm
-        run: npm i -g pnpm
-
-      - name: Install Dependencies
-        run: pnpm i --frozen-lockfile=false
-      - run: npx nx-cloud start-agent
+  #  agent_1:
+  #    runs-on: ubuntu-latest
+  #    name: Agent 1
+  #    timeout-minutes: 60
+  #    steps:
+  #      - uses: actions/checkout@v2
+  #      - uses: actions/setup-node@v1
+  #        with:
+  #          node-version: 14.x
+  #      - name: Install pnpm
+  #        run: npm i -g pnpm
+          #
+  #      - name: Install Dependencies
+  #        run: pnpm i --frozen-lockfile=false
+  #      - run: npx nx-cloud start-agent

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:int": "nx run-many --target=e2e --all",
     "sendCoverage": "codeclimate-test-reporter < coverage/lcov.info",
     "prepare": "husky install",
-    "release": "nx affected --target=publish",
+    "release": "pnpm changeset",
     "nx": "nx",
     "deploy": "nx deploy docs"
   },

--- a/packages/platform-socket.io/package.json
+++ b/packages/platform-socket.io/package.json
@@ -24,10 +24,10 @@
     "url": "https://github.com/jmcdo29/ogma/issues"
   },
   "peerDependencies": {
-    "@nestjs/platform-socket.io": "^7.0.0",
-    "@nestjs/websockets": "^7.0.0",
+    "@nestjs/platform-socket.io": "^8.0.0",
+    "@nestjs/websockets": "^8.0.0",
     "@ogma/nestjs-module": "^3.0.0",
-    "socket.io": "^2.0.0"
+    "socket.io": "^4.0.0"
   },
   "peerDependenciesMeta": {
     "@nestjs/websockets": {


### PR DESCRIPTION
Forgot to update the peer deps. This also tries out a new idea
for a changesets workflow. This _should_ allow for an truly
automated release cycle on my part, which will be really nice.

fixes #651