### PR TITLE
docs(readme): updates documentations link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://github.com/jmcdo29/ogma/workflows/CI/badge.svg) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![Coffee](https://badgen.net/badge/Buy%20Me/A%20Coffee/purple?icon=kofi)](https://www.buymeacoffee.com/jmcdo29) [![codebeat badge](https://codebeat.co/badges/c7019814-38f9-484c-a35f-5b569efd0d0f)](https://codebeat.co/projects/github-com-jmcdo29-ogma-main)
   
   <p align="center">
-    <a href="jmcdo29.github.io/ogma/" target="blank"><img src="apps/docs/static/img/logo.svg" width="120" alt="Ogma Logo" /></a>
+    <a href="https://jmcdo29.github.io/ogma" target="blank"><img src="apps/docs/static/img/logo.svg" width="120" alt="Ogma Logo" /></a>
   </p>
 
 </div>


### PR DESCRIPTION
This PR updates the link as it is broken leads to a page github with 404.

