### PR TITLE
chore: clean up uncessary tsconfig files

### DIFF
--- a/packages/cli/tsconfig.build.json
+++ b/packages/cli/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/cli/tsconfig.spec.json
+++ b/packages/cli/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/common/tsconfig.build.json
+++ b/packages/common/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/common/tsconfig.json
+++ b/packages/common/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/common/tsconfig.spec.json
+++ b/packages/common/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/logger/tsconfig.build.json
+++ b/packages/logger/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/logger/tsconfig.spec.json
+++ b/packages/logger/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/nestjs-module/tsconfig.build.json
+++ b/packages/nestjs-module/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/nestjs-module/tsconfig.json
+++ b/packages/nestjs-module/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/nestjs-module/tsconfig.spec.json
+++ b/packages/nestjs-module/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-express/tsconfig.build.json
+++ b/packages/platform-express/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-express/tsconfig.json
+++ b/packages/platform-express/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-express/tsconfig.spec.json
+++ b/packages/platform-express/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-fastify/tsconfig.build.json
+++ b/packages/platform-fastify/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-fastify/tsconfig.json
+++ b/packages/platform-fastify/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-fastify/tsconfig.spec.json
+++ b/packages/platform-fastify/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-graphql-fastify/tsconfig.build.json
+++ b/packages/platform-graphql-fastify/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-graphql-fastify/tsconfig.json
+++ b/packages/platform-graphql-fastify/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-graphql-fastify/tsconfig.spec.json
+++ b/packages/platform-graphql-fastify/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-graphql/tsconfig.build.json
+++ b/packages/platform-graphql/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-graphql/tsconfig.json
+++ b/packages/platform-graphql/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-graphql/tsconfig.spec.json
+++ b/packages/platform-graphql/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-grpc/tsconfig.build.json
+++ b/packages/platform-grpc/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-grpc/tsconfig.json
+++ b/packages/platform-grpc/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-grpc/tsconfig.spec.json
+++ b/packages/platform-grpc/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-kafka/tsconfig.build.json
+++ b/packages/platform-kafka/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-kafka/tsconfig.json
+++ b/packages/platform-kafka/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-kafka/tsconfig.spec.json
+++ b/packages/platform-kafka/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-mqtt/tsconfig.build.json
+++ b/packages/platform-mqtt/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-mqtt/tsconfig.json
+++ b/packages/platform-mqtt/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-mqtt/tsconfig.spec.json
+++ b/packages/platform-mqtt/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-nats/tsconfig.build.json
+++ b/packages/platform-nats/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-nats/tsconfig.json
+++ b/packages/platform-nats/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-nats/tsconfig.spec.json
+++ b/packages/platform-nats/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-rabbitmq/tsconfig.build.json
+++ b/packages/platform-rabbitmq/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-rabbitmq/tsconfig.json
+++ b/packages/platform-rabbitmq/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-rabbitmq/tsconfig.spec.json
+++ b/packages/platform-rabbitmq/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-redis/tsconfig.build.json
+++ b/packages/platform-redis/tsconfig.build.json
@@ -1,7 +1,7 @@
 {
-  "extends": "./tsconfig.json",
+  "extends": "./../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "src"
   },
-  "exclude": ["test"]
+  "include": ["src"]
 }

--- a/packages/platform-redis/tsconfig.json
+++ b/packages/platform-redis/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-redis/tsconfig.spec.json
+++ b/packages/platform-redis/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-socket.io/tsconfig.build.json
+++ b/packages/platform-socket.io/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "src"
-  },
-  "exclude": ["test"]
+  "extends": "./../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/platform-socket.io/tsconfig.json
+++ b/packages/platform-socket.io/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-socket.io/tsconfig.spec.json
+++ b/packages/platform-socket.io/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-tcp/tsconfig.build.json
+++ b/packages/platform-tcp/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "src"
-  },
-  "exclude": ["test"]
+  "extends": "./../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/platform-tcp/tsconfig.json
+++ b/packages/platform-tcp/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-tcp/tsconfig.spec.json
+++ b/packages/platform-tcp/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/platform-ws/tsconfig.build.json
+++ b/packages/platform-ws/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "src"
-  },
-  "exclude": ["test"]
+  "extends": "./../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/platform-ws/tsconfig.json
+++ b/packages/platform-ws/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/platform-ws/tsconfig.spec.json
+++ b/packages/platform-ws/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/packages/styler/tsconfig.build.json
+++ b/packages/styler/tsconfig.build.json
@@ -1,7 +1,4 @@
 {
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "src"
-  },
-  "exclude": ["test"]
+  "extends": "./../../tsconfig.json",
+  "include": ["src"]
 }

--- a/packages/styler/tsconfig.json
+++ b/packages/styler/tsconfig.json
@@ -1,8 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "compilerOptions": {
-    "rootDir": "./",
-    "outDir": "./lib"
-  },
-  "include": ["./src", "./test"]
-}

--- a/packages/styler/tsconfig.spec.json
+++ b/packages/styler/tsconfig.spec.json
@@ -1,6 +1,0 @@
-{
-  "extends": "./tsconfig.json",
-  "compilerOptions": {
-    "sourceMap": true
-  }
-}

--- a/tools/setup-workspace.ts
+++ b/tools/setup-workspace.ts
@@ -30,7 +30,7 @@ const generatePackage = (projectName: string) => {
     options: {
       outputPath: `dist/${projectName}`,
       main: `packages/${projectName}/src/${mainOverrides[projectName] ?? 'index.ts'}`,
-      tsConfig: `packages/${projectName}/tsconfig.build.json`,
+      tsConfig: `packages/${projectName}/tsconfig.json`,
       deleteOutputPath: true,
       packageJson: `packages/${projectName}/package.json`,
       assets: [`packages/${projectName}/*.md`],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "target": "es2017",
     "sourceMap": false,
     "outDir": "./lib",
-    "baseUrl": ".",
+    "baseUrl": "./",
     "strict": false,
     "noUnusedLocals": false,
     "lib": ["ES7"],


### PR DESCRIPTION
A lot of the tsconfig files that were left in the `packages/<package>` directories messed with VSCode and made errors report like `<file> is not a part of 'rootDir'`. This removes all of the unnecessary files which should help other devs 