### PR TITLE
fix(cli): allow for newlines in log file

### DIFF
--- a/.changeset/tough-pillows-think.md
+++ b/.changeset/tough-pillows-think.md
@@ -1,0 +1,5 @@
+---
+'@ogma/cli': patch
+---
+
+CLI no longer dies on newlines

--- a/packages/cli/src/ogma.command.ts
+++ b/packages/cli/src/ogma.command.ts
@@ -67,11 +67,15 @@ export class OgmaCommand implements CommandRunner {
   }
 
   private async runForFile(fileName: string, options: { color: boolean }): Promise<void> {
-    const logs = await this.readFile(fileName);
+    const logs = (await this.readFile(fileName)).filter((log) => log.trim().length !== 0);
     if (!logs.every((log) => this.checkOgmaFormat(log))) {
       throw new Error(badFormat);
     }
-    logs.map((log) => JSON.parse(log)).forEach((log: OgmaLog) => this.writeLog(log, options.color));
+    logs
+      .map((log) => {
+        return JSON.parse(log);
+      })
+      .forEach((log: OgmaLog) => this.writeLog(log, options.color));
   }
 
   private async readFile(fileName: string): Promise<string[]> {

--- a/packages/cli/test/command.spec.ts
+++ b/packages/cli/test/command.spec.ts
@@ -112,3 +112,22 @@ describe.skip('command line flags', () => {
     );
   });
 });
+
+describe('with blank line', () => {
+  it('should not error when there is a blank line', async () => {
+    jest
+      .spyOn(promises, 'readFile')
+      .mockResolvedValueOnce(
+        Buffer.from(
+          JSON.stringify({ hostname: 'test', level: 'INFO', ool: 'INFO', pid: 1, time: '1' }) +
+            '\n' +
+            JSON.stringify({ hostname: 'test', level: 'INFO', ool: 'INFO', pid: 1, time: '1' }) +
+            '\n' +
+            JSON.stringify({ hostname: 'test', level: 'INFO', ool: 'INFO', pid: 1, time: '1' }) +
+            '\n',
+        ),
+      );
+    await expect(ogmaHydrate(hydrateArgs)).resolves.not.toThrowError();
+    expect(writeSpy).toBeCalledTimes(3);
+  });
+});


### PR DESCRIPTION
By allowing for newlines in the `.log` files we can ensure that
files written do not need to end with no newline which will allow
for a better dev experience when it comes to using the CLI to read
back the written files

fixes #904