### PR TITLE
fix: pass args as array to Function.prototype.apply

### DIFF
--- a/.changeset/cool-pigs-explain.md
+++ b/.changeset/cool-pigs-explain.md
@@ -1,0 +1,5 @@
+---
+'@ogma/nestjs-module': patch
+---
+
+fix defect in @Log decorator that produces an error when the original function was called

--- a/packages/nestjs-module/src/decorators/ogma-logger.decorator.ts
+++ b/packages/nestjs-module/src/decorators/ogma-logger.decorator.ts
@@ -30,7 +30,7 @@ export const Log =
       const logger: OgmaService = this[loggerProperty];
       const context = `${target.constructor.name}#${method}`;
       logger.trace(`Start ${method}`, { context });
-      let result = (impl as any).apply(target, ...args);
+      let result = (impl as any).apply(this, args);
       if (result.then) {
         result.finally(() => {
           logEnd({ context, method }, logger, start);


### PR DESCRIPTION
Function.prototype.apply has call signature `apply(thisArg, argsArray)` so we cannot use spread operator on the arguments