### PR TITLE
fix: add `application` property in `OgmaServiceMeta`

### DIFF
--- a/.changeset/three-bats-wave.md
+++ b/.changeset/three-bats-wave.md
@@ -1,0 +1,5 @@
+---
+'@ogma/nestjs-module': patch
+---
+
+fix: add `application` property in `OgmaServiceMeta`

--- a/packages/nestjs-module/src/interfaces/ogma-service-meta.interface.ts
+++ b/packages/nestjs-module/src/interfaces/ogma-service-meta.interface.ts
@@ -1,4 +1,5 @@
 export interface OgmaServiceMeta {
+  application?: string;
   context?: string;
   correlationId?: string;
   [key: string]: unknown;


### PR DESCRIPTION
From now on, text editor intellisense would list `application` property in an object of `OgmaServiceMeta` type when using `@ogma/nestjs-module`.