### PR TITLE
feat: allow for printing each array value

### DIFF
--- a/.changeset/fluffy-chicken-tie.md
+++ b/.changeset/fluffy-chicken-tie.md
@@ -1,0 +1,6 @@
+---
+'@ogma/logger': minor
+'@ogma/nestjs-module': minor
+---
+
+Allow for printing of each array value

--- a/packages/logger/src/interfaces/ogma-print-options.ts
+++ b/packages/logger/src/interfaces/ogma-print-options.ts
@@ -14,5 +14,11 @@ export interface OgmaPrintOptions {
    * @default ''
    */
   correlationId?: string;
+  /**
+   * set this option to `true` to enable ogma to log multiple items each on a new line, just like
+   * `console.log('Hello', 'how', 'are', 'you?')`. This will only effect the logs if the first parameter
+   * is an array
+   */
+  each?: boolean;
   [key: string]: unknown;
 }

--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -62,6 +62,11 @@ export class Ogma {
   }
 
   private printMessage(message: any, options: PrintMessageOptions): void {
+    if (Array.isArray(message) && options.each) {
+      const { each: _, ...newOpts } = options;
+      message.forEach((m) => this.printMessage(m, newOpts));
+      return;
+    }
     if (options.level < LogLevel[this.options.logLevel]) {
       return;
     }

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -298,5 +298,14 @@ OgmaSuite(
     });
   },
 );
+OgmaSuite('It should not explosively print array values', ({ writeSpy, ogmaFactory }) => {
+  const ogma = ogmaFactory();
+  const messages = [
+    ['Hello', 'World!'],
+    ['How', 'are', 'you?'],
+  ];
+  ogma.log(messages, { each: true });
+  is(writeSpy.calls.size, 2, 'There should only be two calls');
+});
 
 OgmaSuite.run();

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -282,5 +282,21 @@ for (const json of [true, false]) {
     },
   );
 }
+OgmaSuite(
+  'it should print each array value if the option "each" is true',
+  ({ writeSpy, ogmaFactory }) => {
+    const ogma = ogmaFactory();
+    const messages = ['hello', 42, { key: 'value' }, true];
+    ogma.log(messages, { each: true });
+    is(writeSpy.calls.size, 4, 'Expected there to be four calls to the write stream');
+    messages.forEach((message, index) => {
+      const loggedVal = writeSpy.getCall(index)[0];
+      if (typeof message === 'object') {
+        message = JSON.stringify(message, null, 2);
+      }
+      match(loggedVal, message.toString());
+    });
+  },
+);
 
 OgmaSuite.run();

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -290,7 +290,7 @@ OgmaSuite(
     ogma.log(messages, { each: true });
     is(writeSpy.calls.size, 4, 'Expected there to be four calls to the write stream');
     messages.forEach((message, index) => {
-      const loggedVal = writeSpy.getCall(index)[0];
+      const loggedVal = writeSpy.getCall(index).args[0].toString();
       if (typeof message === 'object') {
         message = JSON.stringify(message, null, 2);
       }

--- a/packages/nestjs-module/src/interfaces/ogma-service-meta.interface.ts
+++ b/packages/nestjs-module/src/interfaces/ogma-service-meta.interface.ts
@@ -2,5 +2,6 @@ export interface OgmaServiceMeta {
   application?: string;
   context?: string;
   correlationId?: string;
+  each?: boolean;
   [key: string]: unknown;
 }


### PR DESCRIPTION
With the addition of a new option passed to either `ogma` or the `ogmaService`, the `{ each: true }` flag will tell ogma to recursively call `this.printMessage` and print out each value of the array. It **will not** go deeper than top level as of now, so an array like `[['Hello', 'World'], ['Foo', 'Bar', 'Baz']]` will have two printed values instead of five.

fix #1382 