### PR TITLE
fix: properly log each array entry with each

### DIFF
--- a/.changeset/lemon-candles-float.md
+++ b/.changeset/lemon-candles-float.md
@@ -1,0 +1,8 @@
+---
+'@ogma/logger': patch
+'@ogma/nestjs-module': patch
+---
+
+Update {each: true } to separate via space, not newline
+
+[Read up on the discussion here](https://github.com/jmcdo29/ogma/discussions/1381)

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -414,7 +414,7 @@ sdfg werr`,
   },
 ]) {
   OgmaSuite(
-    `message: ${message.toString().replace(/\n/g, '\\n').replace(/\t/g, '\t')}`,
+    `message: ${message.toString().replace(/\n/g, '\\n').replace(/\t/g, '\\t')}`,
     ({ writeSpy, ogmaFactory, getFirstCallString }) => {
       const ogma = ogmaFactory();
       ogma.log(message, { each: true });

--- a/packages/nestjs-module/test/ogma.service.spec.ts
+++ b/packages/nestjs-module/test/ogma.service.spec.ts
@@ -98,9 +98,9 @@ OgmaServiceSuite('it should print multiple statements', () => {
   const service = new OgmaService(ogma);
   const messages = ['Hello', '42', { hello: 'world' }, true];
   service.log(messages, { each: true });
-  is(streamSpy.calls.size, 4, 'Expected four logs');
+  is(streamSpy.calls.size, 1, 'Expected one logs');
   messages.forEach((message, index) => {
-    const loggedVal = streamSpy.getCall(index).args[0];
+    const loggedVal = streamSpy.getCall(0).args[0];
     if (typeof message === 'object') {
       message = JSON.stringify(message, null, 2);
     }


### PR DESCRIPTION
After extensive discussion with @tukusejssirs on GitHub, the `{each:
true }` now causes each array entry to be separated by a space, not a
newline, and has an extensinve accompnying test suite to ensure all
values are handled as expected.

ref: #1381