### PR TITLE
feat: add ability to log response body as meta

### DIFF
--- a/.changeset/famous-pens-appear.md
+++ b/.changeset/famous-pens-appear.md
@@ -1,0 +1,7 @@
+---
+'@ogma/nestjs-module': minor
+---
+
+Allow for logging out the response body as well
+
+While _technically_ this is a breaking change in the `getContextSuccessString` method, passing the data object instead of the buffer length, to my knowledge there are no custom parsers out there that make use of this method and all `@ogma/*` parsers have been checked that no changes are necessary for them. If this _does_ end up breaking something for someone, I'm sorry.

--- a/apps/docs/docs/nestjs/custom.md
+++ b/apps/docs/docs/nestjs/custom.md
@@ -202,6 +202,25 @@ This is only available in `@ogma/nestjs-module@3.1.0` and higher
 
 :::
 
+An example could look something like this:
+
+```typescript
+@Injectable()
+export class ExpressWithBodyParser extend ExpressParser {
+  getMeta(context: ExecutionContext, data: unknown) {
+    const key = data instanceof Error ? 'error' : 'res';
+    if (key === 'res') {
+      data ??= '';
+    }
+    const { body } = context.switchToHttp().getRequest();
+    return {
+      req: body,
+      [key]: data
+    }
+  }
+}
+```
+
 ## Other Abstract Classes
 
 There are also abstract classes already created for each transport type, `HTTP`, `GQL`, `WS`, and `RPC`. Each of which can be used instead of extending from the base `AbstractInterceptorService` class if you so choose. This helps with needing to implement the minimum amount of logic for the parser.

--- a/packages/nestjs-module/src/interceptor/providers/abstract-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/abstract-interceptor.service.ts
@@ -13,18 +13,20 @@ export abstract class AbstractInterceptorService implements InterceptorService {
   /**
    * A method to transform the incoming execution context into metadata that the OgmaInterceptor will then log.
    * This method handles the success cases
-   * @param dataLength the buffer length of the data
+   * @param data the response body that will be returned
    * @param context the execution context from Nest
    * @param startTime when the request started
    * @param options the options passed to the interceptor
    * @returns an object that represents what should be logged
    */
   getSuccessContext(
-    dataLength: number,
+    data: unknown,
     context: ExecutionContext,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): MetaLogObject {
+    const stringifiedData = data ? JSON.stringify(data) : '';
+    const dataLength = Buffer.from(stringifiedData).byteLength;
     return {
       callerAddress: this.getCallerIp(context),
       method: this.getMethod(context),
@@ -33,7 +35,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
       contentLength: dataLength,
       protocol: this.getProtocol(context),
       status: this.getStatus(context, options.color && !options.json),
-      meta: this.getMeta(context),
+      meta: this.getMeta(context, data),
     };
   }
 
@@ -60,7 +62,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
       responseTime: this.getResponseTime(startTime),
       contentLength: Buffer.from(JSON.stringify(error.message)).byteLength,
       protocol: this.getProtocol(context),
-      meta: this.getMeta(context),
+      meta: this.getMeta(context, error),
     };
   }
 
@@ -79,9 +81,10 @@ export abstract class AbstractInterceptorService implements InterceptorService {
   /**
    * A helper method to allow devs the ability to pass in extra metadata when it comes to the interceptor
    * @param context The ExecutionContext
+   * @param data the response body or the error being returned
    * @returns whatever metadata you want to add in on a second log line. This can be a string, an object, anything
    */
-  getMeta(_context: ExecutionContext): unknown {
+  getMeta(_context: ExecutionContext, _data: unknown): unknown {
     return;
   }
 

--- a/packages/nestjs-module/src/interceptor/providers/delegator.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/delegator.service.ts
@@ -29,8 +29,6 @@ export class DelegatorService {
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): DelegatorContextReturn {
-    data = data ? JSON.stringify(data) : '';
-    data = Buffer.from(data).byteLength;
     const parser: Parser = this.getParser(context.getType());
     const { meta, ...logObject } = this.getContextString({
       method: 'getSuccessContext',

--- a/packages/nestjs-module/test/delegator.service.spec.ts
+++ b/packages/nestjs-module/test/delegator.service.spec.ts
@@ -128,16 +128,7 @@ for (const method of ['getSuccessContext', 'getErrorContext'] as const) {
       const methodName =
         method === 'getSuccessContext' ? 'getContextSuccessString' : 'getContextErrorString';
       equal(delegate[methodName](data, fullContextMock, startTime, options), parsedString);
-      ok(
-        parserSpy.calledWith(
-          method === 'getSuccessContext'
-            ? Buffer.from(JSON.stringify(data)).byteLength
-            : (data as any),
-          fullContextMock,
-          startTime,
-          options,
-        ),
-      );
+      ok(parserSpy.calledWith(data, fullContextMock, startTime, options));
     });
   }
 }
@@ -159,7 +150,7 @@ DelegatorServiceSuite('It should use JSON format instead of string', ({ delegate
     log: parserReturn,
     meta: undefined,
   });
-  ok(parseSpy.calledWith(Buffer.from(JSON.stringify('data')).byteLength, fullCtxMock, 0, options));
+  ok(parseSpy.calledWith('data', fullCtxMock, 0, options));
 });
 DelegatorServiceSuite('It should replace no data with an empty string', ({ delegate, parsers }) => {
   const fullCtxMock = executionMockFactory({ getType: () => 'http' });
@@ -170,7 +161,7 @@ DelegatorServiceSuite('It should replace no data with an empty string', ({ deleg
     log: '127.0.0.1 - GET / HTTP/1.1 200 2ms - 0',
     meta: undefined,
   });
-  ok(parseSpy.calledWith(0, fullCtxMock, 0, options));
+  ok(parseSpy.calledWith(null, fullCtxMock, 0, options));
 });
 
 DelegatorServiceSuite.run();

--- a/packages/nestjs-module/test/noop-interceptor.service.spec.ts
+++ b/packages/nestjs-module/test/noop-interceptor.service.spec.ts
@@ -17,7 +17,7 @@ NoopInterceptorServiceSuite.before(async (context) => {
 });
 NoopInterceptorServiceSuite('It should return a success log object', ({ service }) => {
   Date.now = () => 133;
-  equal(service.getSuccessContext(151, {} as any, 50, {} as any), {
+  equal(service.getSuccessContext(Array(149).fill('o').join(''), {} as any, 50, {} as any), {
     callerAddress: 'caller ip',
     method: 'method',
     callPoint: 'call point',


### PR DESCRIPTION
Made an update to the `AbstractInterceptorService` that passes the
`response.body` to `getMeta` under the second parameter named `data`.
This is either the `data` or the `error` being retured.

While _technically_ this is a breaking change in the
`getContextSuccessString` method, passing the data object instead of the
buffer length, to my knowledge there are no custom parsers out there
that make use of this method and all `@ogma/*` parsers have been checked
that no changes are necessary for them. If this _does_ end up breaking
something for someone, I'm sorry.