### PR TITLE
feat: create new service for logging metadata from filter

### DIFF
--- a/apps/docs/src/config.ts
+++ b/apps/docs/src/config.ts
@@ -73,6 +73,10 @@ export const SIDEBAR: Sidebar = {
         link: 'en/nestjs/interceptor',
       },
       {
+        text: 'Filter Logging',
+        link: 'en/nestjs/filter',
+      },
+      {
         text: 'Configured Example',
         link: 'en/nestjs/example',
       },

--- a/apps/docs/src/pages/en/nestjs/filter.md
+++ b/apps/docs/src/pages/en/nestjs/filter.md
@@ -1,0 +1,24 @@
+---
+id: filter
+title: Filter Logging Service
+layout: ../../../layouts/MainLayout.asrto
+---
+
+There may be times where you need to log an exception that happened outside of the interceptor's control, say like in a guard or a middleware. For this purpose, ogma also comes with an `OgmaFilterService` that takes in the exception and the `ArgumentsHost`, and prints out a line just like the interceptor would. The service is also smart, ensuring not to print out another line to the logs if the exception has already been logged by the interceptor.
+
+To make use of this provider, all that's needed is to inject the service into your filter and call `this.service.log(exception, host)`. This way, any custom filter keeps all of the logic in your hands while allowing for logging of the exception.
+
+```ts
+import { BaseExceptionFilter, Catch } from '@nestjs/common';
+import { OgmaFilterService } from '@ogma/nestjs-module';
+
+@Catch()
+export class CustomExceptionFilter extends BaseExceptionFilter {
+  constructor(private readonly service: OgmaFilterService) {}
+
+  catch(exception: Error, host: ArgumentsHost) {
+    this.service.log(exception, host);
+    super.catch(exception, host);
+  }
+}
+```

--- a/apps/docs/src/pages/en/nestjs/filter.md
+++ b/apps/docs/src/pages/en/nestjs/filter.md
@@ -1,7 +1,7 @@
 ---
 id: filter
 title: Filter Logging Service
-layout: ../../../layouts/MainLayout.asrto
+layout: ../../../layouts/MainLayout.astro
 ---
 
 There may be times where you need to log an exception that happened outside of the interceptor's control, say like in a guard or a middleware. For this purpose, ogma also comes with an `OgmaFilterService` that takes in the exception and the `ArgumentsHost`, and prints out a line just like the interceptor would. The service is also smart, ensuring not to print out another line to the logs if the exception has already been logged by the interceptor.

--- a/apps/docs/src/styles/theme.css
+++ b/apps/docs/src/styles/theme.css
@@ -20,7 +20,7 @@
   --color-base-white: 0, 0%;
   --color-base-black: 240, 100%;
   --color-base-gray: 215, 14%;
-  --color-base-blue: 212, 100%;
+  --color-base-blue: 206.2, 58.8%;
   --color-base-blue-dark: 212, 72%;
   --color-base-green: 158, 79%;
   --color-base-orange: 22, 100%;
@@ -74,7 +74,7 @@
   --theme-code-inline-text: var(--theme-text);
   --theme-code-bg: hsla(217, 19%, 27%, 1);
   --theme-code-text: hsla(var(--color-gray-95), 1);
-  --theme-navbar-bg: hsla(var(--color-base-white), 100%, 1);
+  --theme-navbar-bg: hsla(var(--color-blue), 0.5);
   --theme-navbar-height: 6rem;
   --theme-selection-color: hsla(var(--color-blue), 1);
   --theme-selection-bg: hsla(var(--color-blue), var(--theme-accent-opacity));
@@ -96,14 +96,14 @@ body {
 
   /* @@@: not used anywhere */
   --theme-text-lighter: hsla(var(--color-gray-40), 1);
-  --theme-bg: hsla(215, 28%, 17%, 1);
+  --theme-bg: hsla(240, 6.9%, 17%, 1);
   --theme-bg-hover: hsla(var(--color-gray-40), 1);
   --theme-bg-offset: hsla(var(--color-gray-5), 1);
   --theme-code-inline-bg: hsla(var(--color-gray-10), 1);
   --theme-code-inline-text: hsla(var(--color-base-white), 100%, 1);
   --theme-code-bg: hsla(var(--color-gray-5), 1);
   --theme-code-text: hsla(var(--color-base-white), 100%, 1);
-  --theme-navbar-bg: hsla(215, 28%, 17%, 1);
+  --theme-navbar-bg: hsla(var(--color-blue), 0.6);
   --theme-selection-color: hsla(var(--color-base-white), 100%, 1);
   --theme-selection-bg: hsla(var(--color-purple), var(--theme-accent-opacity));
 

--- a/integration/src/gql/exception.filter.ts
+++ b/integration/src/gql/exception.filter.ts
@@ -4,11 +4,11 @@ import {
   ExceptionFilter as NestExceptionFilter,
   HttpException,
 } from '@nestjs/common';
-import { OgmaFilterLogger } from '@ogma/nestjs-module';
+import { OgmaFilterService } from '@ogma/nestjs-module';
 
 @Catch()
 export class ExceptionFilter implements NestExceptionFilter {
-  constructor(private readonly service: OgmaFilterLogger) {}
+  constructor(private readonly service: OgmaFilterService) {}
   catch(exception: HttpException, host: ArgumentsHost) {
     this.service.log(exception, host);
     return exception;

--- a/integration/src/gql/exception.filter.ts
+++ b/integration/src/gql/exception.filter.ts
@@ -11,11 +11,6 @@ export class ExceptionFilter implements NestExceptionFilter {
   constructor(private readonly service: OgmaFilterLogger) {}
   catch(exception: HttpException, host: ArgumentsHost) {
     this.service.log(exception, host);
-    const client = host.switchToWs().getClient();
-    if (client._isServer) {
-      return client.send('exception');
-    } else {
-      return client.emit('exception', exception.message);
-    }
+    return exception;
   }
 }

--- a/integration/src/gql/gql.resolver.ts
+++ b/integration/src/gql/gql.resolver.ts
@@ -1,11 +1,14 @@
-import { BadRequestException } from '@nestjs/common';
+import { BadRequestException, UseFilters, UseGuards } from '@nestjs/common';
 import { Mutation, Query, Resolver } from '@nestjs/graphql';
 import { OgmaSkip } from '@ogma/nestjs-module';
 
 import { AppService } from '../app.service';
+import { FailGuard } from '../shared/fail.guard';
+import { ExceptionFilter } from './exception.filter';
 import { SimpleObject } from './simple-object.model';
 
 @Resolver(() => SimpleObject)
+@UseFilters(ExceptionFilter)
 export class GqlResolver {
   constructor(private readonly appService: AppService) {}
 
@@ -27,6 +30,12 @@ export class GqlResolver {
   @OgmaSkip()
   @Query(() => SimpleObject)
   getSkip(): SimpleObject {
+    return this.appService.getHello();
+  }
+
+  @Query(() => SimpleObject)
+  @UseGuards(FailGuard)
+  failGuard(): SimpleObject {
     return this.appService.getHello();
   }
 }

--- a/integration/src/http/error-logging.filter.ts
+++ b/integration/src/http/error-logging.filter.ts
@@ -1,0 +1,15 @@
+import { ArgumentsHost, Catch } from '@nestjs/common';
+import { BaseExceptionFilter } from '@nestjs/core';
+import { OgmaFilterLogger } from '@ogma/nestjs-module';
+
+@Catch()
+export class ErrorLoggingFilter extends BaseExceptionFilter {
+  constructor(private readonly logger: OgmaFilterLogger) {
+    super();
+  }
+
+  catch(exception: Error, host: ArgumentsHost) {
+    this.logger.log(exception, host);
+    return super.catch(exception, host);
+  }
+}

--- a/integration/src/http/error-logging.filter.ts
+++ b/integration/src/http/error-logging.filter.ts
@@ -1,10 +1,10 @@
 import { ArgumentsHost, Catch } from '@nestjs/common';
 import { BaseExceptionFilter } from '@nestjs/core';
-import { OgmaFilterLogger } from '@ogma/nestjs-module';
+import { OgmaFilterService } from '@ogma/nestjs-module';
 
 @Catch()
 export class ErrorLoggingFilter extends BaseExceptionFilter {
-  constructor(private readonly logger: OgmaFilterLogger) {
+  constructor(private readonly logger: OgmaFilterService) {
     super();
   }
 

--- a/integration/src/http/http.controller.ts
+++ b/integration/src/http/http.controller.ts
@@ -7,13 +7,18 @@ import {
   Patch,
   Post,
   Put,
+  UseFilters,
+  UseGuards,
 } from '@nestjs/common';
 import { OgmaSkip } from '@ogma/nestjs-module';
 
 import { AppService } from '../app.service';
+import { FailGuard } from '../shared/fail.guard';
 import { SimpleObject } from '../simple-object.model';
+import { ErrorLoggingFilter } from './error-logging.filter';
 
 @Controller()
+@UseFilters(ErrorLoggingFilter)
 export class HttpController {
   constructor(private readonly appService: AppService) {}
 
@@ -37,6 +42,12 @@ export class HttpController {
   @OgmaSkip()
   getSkip(): SimpleObject {
     return this.appService.getHello();
+  }
+
+  @Get('fail-guard')
+  @UseGuards(FailGuard)
+  failGuard() {
+    /* no op */
   }
 
   @Post()

--- a/integration/src/rpc/client/rpc-client.controller.ts
+++ b/integration/src/rpc/client/rpc-client.controller.ts
@@ -26,4 +26,10 @@ export class RpcClientController implements OnApplicationBootstrap {
   getSkip() {
     return this.micro.send({ cmd: 'skip' }, { ip: '127.0.0.1' });
   }
+
+  @Get('fail-guard')
+  @UseFilters(ExceptionFilter)
+  failGuard() {
+    return this.micro.send({ cmd: 'fail-guard' }, { ip: '127.0.0.1' });
+  }
 }

--- a/integration/src/rpc/server/rpc-server.controller.ts
+++ b/integration/src/rpc/server/rpc-server.controller.ts
@@ -1,8 +1,9 @@
-import { BadRequestException, Controller, UseFilters } from '@nestjs/common';
+import { BadRequestException, Controller, UseFilters, UseGuards } from '@nestjs/common';
 import { MessagePattern } from '@nestjs/microservices';
 import { OgmaSkip } from '@ogma/nestjs-module';
 
 import { AppService } from '../../app.service';
+import { FailGuard } from '../../shared/fail.guard';
 import { ExceptionFilter } from './../../shared/server-exception.filter';
 
 @Controller()
@@ -24,5 +25,12 @@ export class RpcServerController {
   @MessagePattern({ cmd: 'skip' })
   getSkip() {
     return this.appService.getHello();
+  }
+
+  @MessagePattern({ cmd: 'fail-guard' })
+  @UseFilters(ExceptionFilter)
+  @UseGuards(FailGuard)
+  failGuard() {
+    /* no op */
   }
 }

--- a/integration/src/shared/exception.filter.ts
+++ b/integration/src/shared/exception.filter.ts
@@ -1,8 +1,12 @@
-import { ArgumentsHost, Catch, HttpException } from '@nestjs/common';
-import { BaseExceptionFilter } from '@nestjs/core';
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter as NestExceptionFilter,
+  HttpException,
+} from '@nestjs/common';
 
 @Catch()
-export class ExceptionFilter extends BaseExceptionFilter {
+export class ExceptionFilter implements NestExceptionFilter {
   catch(exception: HttpException, host: ArgumentsHost) {
     const res = host.switchToHttp().getResponse();
     res.send(exception);

--- a/integration/src/shared/fail.guard.ts
+++ b/integration/src/shared/fail.guard.ts
@@ -1,0 +1,8 @@
+import { CanActivate, Injectable } from '@nestjs/common';
+
+@Injectable()
+export class FailGuard implements CanActivate {
+  canActivate() {
+    return false;
+  }
+}

--- a/integration/src/shared/server-exception.filter.ts
+++ b/integration/src/shared/server-exception.filter.ts
@@ -1,10 +1,15 @@
-import { Catch, HttpException } from '@nestjs/common';
+import { ArgumentsHost, Catch, HttpException, Optional } from '@nestjs/common';
 import { BaseRpcExceptionFilter } from '@nestjs/microservices';
+import { OgmaFilterLogger } from '@ogma/nestjs-module';
 import { Observable, throwError } from 'rxjs';
 
 @Catch()
 export class ExceptionFilter extends BaseRpcExceptionFilter {
-  catch(exception: HttpException): Observable<any> {
+  constructor(@Optional() private readonly service?: OgmaFilterLogger) {
+    super();
+  }
+  catch(exception: HttpException, host: ArgumentsHost): Observable<any> {
+    this.service?.log(exception, host);
     return throwError(() => exception);
   }
 }

--- a/integration/src/shared/server-exception.filter.ts
+++ b/integration/src/shared/server-exception.filter.ts
@@ -1,11 +1,11 @@
 import { ArgumentsHost, Catch, HttpException, Optional } from '@nestjs/common';
 import { BaseRpcExceptionFilter } from '@nestjs/microservices';
-import { OgmaFilterLogger } from '@ogma/nestjs-module';
+import { OgmaFilterService } from '@ogma/nestjs-module';
 import { Observable, throwError } from 'rxjs';
 
 @Catch()
 export class ExceptionFilter extends BaseRpcExceptionFilter {
-  constructor(@Optional() private readonly service?: OgmaFilterLogger) {
+  constructor(@Optional() private readonly service?: OgmaFilterService) {
     super();
   }
   catch(exception: HttpException, host: ArgumentsHost): Observable<any> {

--- a/integration/src/ws/ws.filter.ts
+++ b/integration/src/ws/ws.filter.ts
@@ -4,11 +4,11 @@ import {
   ExceptionFilter as NestExceptionFilter,
   HttpException,
 } from '@nestjs/common';
-import { OgmaFilterLogger } from '@ogma/nestjs-module';
+import { OgmaFilterService } from '@ogma/nestjs-module';
 
 @Catch()
 export class ExceptionFilter implements NestExceptionFilter {
-  constructor(private readonly service: OgmaFilterLogger) {}
+  constructor(private readonly service: OgmaFilterService) {}
   catch(exception: HttpException, host: ArgumentsHost) {
     this.service.log(exception, host);
     const client = host.switchToWs().getClient();

--- a/integration/src/ws/ws.gateway.ts
+++ b/integration/src/ws/ws.gateway.ts
@@ -1,8 +1,9 @@
-import { BadRequestException, UseFilters, UseInterceptors } from '@nestjs/common';
+import { BadRequestException, UseFilters, UseGuards, UseInterceptors } from '@nestjs/common';
 import { SubscribeMessage, WebSocketGateway } from '@nestjs/websockets';
 import { OgmaInterceptor, OgmaSkip } from '@ogma/nestjs-module';
 
 import { AppService } from '../app.service';
+import { FailGuard } from '../shared/fail.guard';
 import { SimpleObject } from '../simple-object.model';
 import { ExceptionFilter } from './ws.filter';
 
@@ -26,5 +27,12 @@ export class WsGateway {
   @OgmaSkip()
   getSkip(): { event: string; data: SimpleObject } {
     return { event: 'message', data: this.appService.getHello() };
+  }
+
+  @SubscribeMessage('fail-guard')
+  @UseGuards(FailGuard)
+  @UseFilters(ExceptionFilter)
+  failGuard(): void {
+    /* no op */
   }
 }

--- a/integration/test/gql.spec.ts
+++ b/integration/test/gql.spec.ts
@@ -3,7 +3,7 @@ import { INestApplication } from '@nestjs/common';
 import { MercuriusDriver } from '@nestjs/mercurius';
 import { ExpressAdapter } from '@nestjs/platform-express';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
-import { OgmaFilterLogger, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
+import { OgmaFilterService, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
 import { GraphQLParser } from '@ogma/platform-graphql';
 import { GraphQLFastifyParser } from '@ogma/platform-graphql-fastify';
 import { style } from '@ogma/styler';
@@ -39,8 +39,8 @@ for (const { adapter, server, parser, driver } of [
   const GqlParserSuite = suite<{
     app: INestApplication;
     logSpy: Stub<OgmaInterceptor['log']>;
-    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterLogger['doLog']>[];
-    filterSpy: Stub<OgmaFilterLogger['doLog']>;
+    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterService['doLog']>[];
+    filterSpy: Stub<OgmaFilterService['doLog']>;
   }>(`${server} GraphQL server`, {
     app: undefined,
     logSpy: undefined,
@@ -56,7 +56,7 @@ for (const { adapter, server, parser, driver } of [
     });
     context.app = modRef.createNestApplication(adapter);
     const interceptor = context.app.get(OgmaInterceptor);
-    const filterService = context.app.get(OgmaFilterLogger);
+    const filterService = context.app.get(OgmaFilterService);
     await context.app.listen(0);
     const baseUrl = await context.app.getUrl();
     request.setBaseUrl(baseUrl.replace('[::1]', 'localhost'));

--- a/integration/test/http.spec.ts
+++ b/integration/test/http.spec.ts
@@ -1,7 +1,7 @@
 import { INestApplication } from '@nestjs/common';
 import { ExpressAdapter } from '@nestjs/platform-express';
 import { FastifyAdapter } from '@nestjs/platform-fastify';
-import { OgmaFilterLogger, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
+import { OgmaFilterService, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
 import { ExpressParser } from '@ogma/platform-express';
 import { FastifyParser } from '@ogma/platform-fastify';
 import { style } from '@ogma/styler';
@@ -19,13 +19,13 @@ import {
   toBeALogObject,
 } from './utils';
 
-const expectRequestId = (spy: Stub<OgmaInterceptor['log']> | Stub<OgmaFilterLogger['doLog']>) => {
+const expectRequestId = (spy: Stub<OgmaInterceptor['log']> | Stub<OgmaFilterService['doLog']>) => {
   is(typeof spy.firstCall.args[2], 'string');
   is(spy.firstCall.args[2].length, 16);
 };
 
 const expectLogObject = (
-  spy: Stub<OgmaInterceptor['log']> | Stub<OgmaFilterLogger['doLog']>,
+  spy: Stub<OgmaInterceptor['log']> | Stub<OgmaFilterService['doLog']>,
   method: string,
   endpoint: string,
   status: string,
@@ -49,8 +49,8 @@ for (const { adapter, server, parser } of [
   const HttpSuite = suite<{
     app: INestApplication;
     logSpy: Stub<OgmaInterceptor['log']>;
-    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterLogger['doLog']>[];
-    filterSpy: Stub<OgmaFilterLogger['doLog']>;
+    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterService['doLog']>[];
+    filterSpy: Stub<OgmaFilterService['doLog']>;
   }>(`${server} HTTP Log Suite`, {
     app: undefined,
     logSpy: undefined,
@@ -64,7 +64,7 @@ for (const { adapter, server, parser } of [
     });
     context.app = modRef.createNestApplication(adapter);
     const interceptor = context.app.get(OgmaInterceptor);
-    const filterService = context.app.get(OgmaFilterLogger);
+    const filterService = context.app.get(OgmaFilterService);
     await context.app.listen(0);
     request.setBaseUrl((await context.app.getUrl()).replace('[::1]', 'localhost'));
     context.logSpy = stubMethod(interceptor, 'log');

--- a/integration/test/rpc.spec.ts
+++ b/integration/test/rpc.spec.ts
@@ -9,7 +9,7 @@ import {
   Transport,
 } from '@nestjs/microservices';
 import { Test } from '@nestjs/testing';
-import { OgmaFilterLogger, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
+import { OgmaFilterService, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
 import { MqttParser } from '@ogma/platform-mqtt';
 import { NatsParser } from '@ogma/platform-nats';
 import { RabbitMqParser } from '@ogma/platform-rabbitmq';
@@ -84,10 +84,10 @@ for (const { server, transport, options, protocol, parser } of [
 ] as const) {
   const RpcSuite = suite<{
     logSpy: Stub<OgmaInterceptor['log']>;
-    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterLogger['doLog']>[];
+    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterService['doLog']>[];
     rpcServer: INestMicroservice;
     rpcClient: INestApplication;
-    filterSpy: Stub<OgmaFilterLogger['doLog']>;
+    filterSpy: Stub<OgmaFilterService['doLog']>;
   }>(`${server} interceptor suite`, {
     logs: [],
     logSpy: undefined,
@@ -107,7 +107,7 @@ for (const { server, transport, options, protocol, parser } of [
       options,
     } as any);
     const interceptor = rpcServer.get(OgmaInterceptor);
-    const filterService = rpcServer.get(OgmaFilterLogger);
+    const filterService = rpcServer.get(OgmaFilterService);
     await rpcServer.listen().catch(console.error);
     const clientRef = await Test.createTestingModule({
       imports: [

--- a/integration/test/utils/index.ts
+++ b/integration/test/utils/index.ts
@@ -1,4 +1,9 @@
-import { OgmaInterceptor, OgmaService, OgmaServiceOptions } from '@ogma/nestjs-module';
+import {
+  OgmaFilterLogger,
+  OgmaInterceptor,
+  OgmaService,
+  OgmaServiceOptions,
+} from '@ogma/nestjs-module';
 
 const stream = process.stdout;
 process.stdout.getColorDepth = () => 8;
@@ -10,14 +15,19 @@ export const serviceOptionsFactory = (app: string, json = false): OgmaServiceOpt
   return { application: app, stream, json };
 };
 
-export const reportValues = (ogma: OgmaService, logs: Parameters<OgmaInterceptor['log']>[]) => {
+export const reportValues = (
+  ogma: OgmaService,
+  logs: Parameters<OgmaInterceptor['log'] | OgmaFilterLogger['doLog']>[],
+) => {
   if (process.env.CI) {
     return;
   }
   console.log('\n');
   for (const log of logs) {
     ogma.info(log[0], {
-      context: `${log[1].getClass().name}#${log[1].getHandler().name}`,
+      context: log[1]
+        ? `${log[1]?.getClass().name}#${log[1]?.getHandler().name}`
+        : 'ExceptionFilter',
       correlationId: log[2] ?? '',
     });
   }

--- a/integration/test/utils/index.ts
+++ b/integration/test/utils/index.ts
@@ -1,5 +1,5 @@
 import {
-  OgmaFilterLogger,
+  OgmaFilterService,
   OgmaInterceptor,
   OgmaService,
   OgmaServiceOptions,
@@ -17,7 +17,7 @@ export const serviceOptionsFactory = (app: string, json = false): OgmaServiceOpt
 
 export const reportValues = (
   ogma: OgmaService,
-  logs: Parameters<OgmaInterceptor['log'] | OgmaFilterLogger['doLog']>[],
+  logs: Parameters<OgmaInterceptor['log'] | OgmaFilterService['doLog']>[],
 ) => {
   if (process.env.CI) {
     return;

--- a/integration/test/ws.spec.ts
+++ b/integration/test/ws.spec.ts
@@ -2,7 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { IoAdapter } from '@nestjs/platform-socket.io';
 import { WsAdapter } from '@nestjs/platform-ws';
 import { Test } from '@nestjs/testing';
-import { OgmaFilterLogger, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
+import { OgmaFilterService, OgmaInterceptor, OgmaService } from '@ogma/nestjs-module';
 import { SocketIOParser } from '@ogma/platform-socket.io';
 import { WsParser } from '@ogma/platform-ws';
 import { style } from '@ogma/styler';
@@ -37,11 +37,11 @@ for (const { adapter, server, parser, client, protocol, sendMethod, serializer }
 ] as const) {
   const WsSuite = suite<{
     logSpy: Stub<OgmaInterceptor['log']>;
-    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterLogger['doLog']>[];
+    logs: Parameters<OgmaInterceptor['log'] | OgmaFilterService['doLog']>[];
     app: INestApplication;
     baseUrl: string;
     wsClient: { send: (message: string) => Promise<string>; close: () => Promise<void> };
-    filterSpy: Stub<OgmaFilterLogger['doLog']>;
+    filterSpy: Stub<OgmaFilterService['doLog']>;
   }>(`${server} interceptor suite`, {
     logs: [],
     logSpy: undefined,
@@ -64,7 +64,7 @@ for (const { adapter, server, parser, client, protocol, sendMethod, serializer }
     context.app = modRef.createNestApplication();
     context.app.useWebSocketAdapter(new adapter(context.app));
     const interceptor = context.app.get(OgmaInterceptor);
-    const filterService = context.app.get(OgmaFilterLogger);
+    const filterService = context.app.get(OgmaFilterService);
     context.logSpy = stubMethod(interceptor, 'log');
     context.filterSpy = stubMethod(filterService as any, 'doLog');
     context.filterSpy.passThrough();

--- a/packages/nestjs-module/src/filter/ogma-filter.logger.ts
+++ b/packages/nestjs-module/src/filter/ogma-filter.logger.ts
@@ -1,0 +1,49 @@
+import { ArgumentsHost, Injectable } from '@nestjs/common';
+import { OgmaOptions } from '@ogma/logger';
+
+import { InjectOgmaInterceptorOptions } from '../decorators';
+import { LogObject } from '../interceptor/interfaces/log.interface';
+import { DelegatorService } from '../interceptor/providers';
+import { OgmaInterceptorOptions } from '../interfaces';
+import { OgmaService } from '../ogma.service';
+
+@Injectable()
+export class OgmaFilterLogger {
+  private json: boolean;
+  private color: boolean;
+
+  constructor(
+    private readonly service: OgmaService,
+    private readonly delegator: DelegatorService,
+    @InjectOgmaInterceptorOptions() private readonly options: OgmaInterceptorOptions,
+  ) {
+    const ogmaOptions: OgmaOptions = (this.service as any).ogma.options;
+    this.json = ogmaOptions.json;
+    this.color = ogmaOptions.color;
+  }
+
+  log(exception: Error, host: ArgumentsHost): void {
+    if (this.hasAlreadyBeenLogged(host)) {
+      return;
+    }
+    const valueToLog = this.delegator.getContextErrorString(
+      exception,
+      host,
+      this.delegator.getStartTime(host),
+      {
+        ...this.options,
+        json: this.json,
+        color: this.color,
+      },
+    );
+    this.doLog(valueToLog.log);
+  }
+
+  private doLog(valueToLog: string | LogObject): void {
+    this.service.log(valueToLog, { context: 'ExceptionFilter' });
+  }
+
+  private hasAlreadyBeenLogged(host: ArgumentsHost): boolean {
+    return !!this.delegator.getRequestId(host);
+  }
+}

--- a/packages/nestjs-module/src/index.ts
+++ b/packages/nestjs-module/src/index.ts
@@ -1,4 +1,5 @@
 export * from './decorators';
+export * from './filter/ogma-filter.logger';
 export * from './interceptor/ogma.interceptor';
 export * from './interceptor/providers';
 export * from './interfaces/ogma-options.interface';

--- a/packages/nestjs-module/src/index.ts
+++ b/packages/nestjs-module/src/index.ts
@@ -1,8 +1,8 @@
 export * from './decorators';
-export * from './filter/ogma-filter.logger';
 export * from './interceptor/ogma.interceptor';
 export * from './interceptor/providers';
 export * from './interfaces/ogma-options.interface';
 export * from './ogma.module';
 export { createProviderToken } from './ogma.provider';
 export * from './ogma.service';
+export * from './ogma-filter.service';

--- a/packages/nestjs-module/src/interceptor/interfaces/interceptor-service.interface.ts
+++ b/packages/nestjs-module/src/interceptor/interfaces/interceptor-service.interface.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, HttpException } from '@nestjs/common';
+import { ArgumentsHost, ExecutionContext, HttpException } from '@nestjs/common';
 
 import { OgmaInterceptorServiceOptions } from '../../interfaces/ogma-options.interface';
 import { LogObject } from './log.interface';
@@ -13,15 +13,17 @@ export interface InterceptorMeta {
 export interface InterceptorService {
   getSuccessContext(
     data: number,
-    context: ExecutionContext,
+    context: ArgumentsHost,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): LogObject;
 
   getErrorContext(
     error: Error | HttpException,
-    context: ExecutionContext,
+    context: ArgumentsHost,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): LogObject;
+
+  getStartTime(host: ArgumentsHost): number;
 }

--- a/packages/nestjs-module/src/interceptor/providers/abstract-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/abstract-interceptor.service.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, HttpException, Injectable } from '@nestjs/common';
+import { ArgumentsHost, HttpException, Injectable } from '@nestjs/common';
 import { Reflector } from '@nestjs/core';
 import { style } from '@ogma/styler';
 
@@ -21,7 +21,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
    */
   getSuccessContext(
     data: unknown,
-    context: ExecutionContext,
+    context: ArgumentsHost,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): MetaLogObject {
@@ -50,7 +50,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
    */
   getErrorContext(
     error: Error | HttpException,
-    context: ExecutionContext,
+    context: ArgumentsHost,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): MetaLogObject {
@@ -68,23 +68,23 @@ export abstract class AbstractInterceptorService implements InterceptorService {
 
   /**
    * A helper method to get the status based on if the request was an error or success
-   * @param context the execution context
+   * @param _context the execution context
    * @param inColor if the status should be in color
    * @param error if it was an error
    * @returns a string representing the status
    */
-  getStatus(_context: ExecutionContext, inColor: boolean, error?: HttpException | Error): string {
+  getStatus(_context: ArgumentsHost, inColor: boolean, error?: HttpException | Error): string {
     const status = error ? 500 : 200;
     return inColor ? this.wrapInColor(status) : status.toString();
   }
 
   /**
    * A helper method to allow devs the ability to pass in extra metadata when it comes to the interceptor
-   * @param context The ExecutionContext
-   * @param data the response body or the error being returned
+   * @param _context The ArgumentsHost
+   * @param _data the response body or the error being returned
    * @returns whatever metadata you want to add in on a second log line. This can be a string, an object, anything
    */
-  getMeta(_context: ExecutionContext, _data: unknown): unknown {
+  getMeta(_context: ArgumentsHost, _data: unknown): unknown {
     return;
   }
 
@@ -92,7 +92,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
    * A helper method to get the Ip of the calling client
    * @param context the execution context
    */
-  abstract getCallerIp(context: ExecutionContext): string[] | string;
+  abstract getCallerIp(context: ArgumentsHost): string[] | string;
 
   /**
    * A helper method to get the method type of the request
@@ -107,7 +107,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
    *
    * @param context the execution context
    */
-  abstract getMethod(context: ExecutionContext): string;
+  abstract getMethod(context: ArgumentsHost): string;
 
   private getResponseTime(startTime: number): number {
     return Date.now() - startTime;
@@ -117,7 +117,7 @@ export abstract class AbstractInterceptorService implements InterceptorService {
    * A helper method to get the protocol of the request
    * @param context execution context from Nest
    */
-  abstract getProtocol(context: ExecutionContext): string;
+  abstract getProtocol(context: ArgumentsHost): string;
 
   /**
    * A helper method to get what was called
@@ -131,14 +131,14 @@ export abstract class AbstractInterceptorService implements InterceptorService {
    * WebSockets: Subscription Event name
    * @param context execution context from Nest
    */
-  abstract getCallPoint(context: ExecutionContext): string;
+  abstract getCallPoint(context: ArgumentsHost): string;
 
   /**
    * A helper method for setting the correlationId to later be retrieved when logging
    * @param context the execution context
    * @param requestId the correlationId to set
    */
-  abstract setRequestId(context: ExecutionContext, requestId: string): void;
+  abstract setRequestId(context: ArgumentsHost, requestId: string): void;
 
   protected wrapInColor(status: number): string {
     let statusString: string;
@@ -158,5 +158,9 @@ export abstract class AbstractInterceptorService implements InterceptorService {
 
   protected isBetween(comparator: number, bottom: number, top: number): boolean {
     return comparator >= bottom && comparator < top;
+  }
+
+  getStartTime(_host: ArgumentsHost): number {
+    return Date.now();
   }
 }

--- a/packages/nestjs-module/src/interceptor/providers/delegator.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/delegator.service.ts
@@ -1,4 +1,4 @@
-import { ContextType, ExecutionContext, Injectable } from '@nestjs/common';
+import { ArgumentsHost, ContextType, Injectable } from '@nestjs/common';
 
 import { OgmaInterceptorServiceOptions } from '../../interfaces';
 import { DelegatorContextReturn, LogObject, MetaLogObject } from '../interfaces/log.interface';
@@ -18,14 +18,19 @@ export class DelegatorService {
     private readonly gqlParser: GqlInterceptorService,
   ) {}
 
-  setRequestId(context: ExecutionContext, requestId: string): void {
+  setRequestId(context: ArgumentsHost, requestId: string): void {
     const parser: Parser = this.getParser(context.getType());
     this[parser].setRequestId(context, requestId);
   }
 
+  getRequestId(context: ArgumentsHost): any {
+    const parser = this.getParser(context.getType());
+    return this[parser].getRequestId(context);
+  }
+
   getContextSuccessString(
     data: any,
-    context: ExecutionContext,
+    context: ArgumentsHost,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): DelegatorContextReturn {
@@ -62,7 +67,7 @@ export class DelegatorService {
 
   getContextErrorString(
     error: any,
-    context: ExecutionContext,
+    context: ArgumentsHost,
     startTime: number,
     options: OgmaInterceptorServiceOptions,
   ): DelegatorContextReturn {
@@ -88,7 +93,7 @@ export class DelegatorService {
   }: {
     method: 'getErrorContext' | 'getSuccessContext';
     data: any;
-    context: ExecutionContext;
+    context: ArgumentsHost;
     startTime: number;
     options: OgmaInterceptorServiceOptions;
     parser: Parser;
@@ -100,5 +105,10 @@ export class DelegatorService {
     return options.json
       ? data
       : `${data.callerAddress} - ${data.method} ${data.callPoint} ${data.protocol} ${data.status} ${data.responseTime}ms - ${data.contentLength}`;
+  }
+
+  getStartTime(host: ArgumentsHost): number {
+    const parser = this.getParser(host.getType());
+    return this[parser].getStartTime(host);
   }
 }

--- a/packages/nestjs-module/src/interceptor/providers/gql-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/gql-interceptor.service.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ArgumentsHost, Injectable } from '@nestjs/common';
 
 import { AbstractInterceptorService } from './abstract-interceptor.service';
 
@@ -13,20 +13,25 @@ export abstract class GqlInterceptorService extends AbstractInterceptorService {
    *
    * this method _should_ look something like this
    * ```ts
-   * getContext(context: ExecutionContext) {
-   *   const gql = GqlExecutionContext.create(context);
+   * getContext(context: ArgumentsHost) {
+   *   const gql = GqlArgumentsHost.create(context);
    *   return gql.getContext();
    * }
    * ```
    * @param context execution context from Nest
    */
-  protected abstract getContext(context: ExecutionContext): any;
-  setRequestId(context: ExecutionContext, requestId: string) {
+  protected abstract getContext(context: ArgumentsHost): any;
+  setRequestId(context: ArgumentsHost, requestId: string) {
     const ctx = this.getContext(context).context;
     if (ctx[this.reqName]) {
       ctx[this.reqName].requestId = requestId;
     } else {
       ctx.requestId = requestId;
     }
+  }
+
+  getRequestId(context: ArgumentsHost): any {
+    const ctx = this.getContext(context).context;
+    return ctx[this.reqName]?.requestId ?? ctx.requestId;
   }
 }

--- a/packages/nestjs-module/src/interceptor/providers/rpc-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/rpc-interceptor.service.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ArgumentsHost, ExecutionContext, Injectable } from '@nestjs/common';
 
 import { AbstractInterceptorService } from './abstract-interceptor.service';
 
@@ -13,7 +13,7 @@ export abstract class RpcInterceptorService extends AbstractInterceptorService {
    * @param context execution context from Nest
    * @returns The data object for the RPC adapter
    */
-  getData<T>(context: ExecutionContext): T {
+  getData<T>(context: ArgumentsHost): T {
     return context.switchToRpc().getData();
   }
 
@@ -22,7 +22,16 @@ export abstract class RpcInterceptorService extends AbstractInterceptorService {
    * @param context execution context from Nest
    * @returns The client object for the RPC adapter
    */
-  getClient<T = unknown>(context: ExecutionContext): T {
+  getClient<T = unknown>(context: ArgumentsHost): T {
     return context.switchToRpc().getContext();
+  }
+
+  setRequestId(context: ArgumentsHost, requestId: any): void {
+    const client = this.getClient<{ requestId: any }>(context);
+    client.requestId = requestId;
+  }
+
+  getRequestId(context: ArgumentsHost): any {
+    return this.getClient<{ requestId: any }>(context).requestId;
   }
 }

--- a/packages/nestjs-module/src/interceptor/providers/websocket-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/websocket-interceptor.service.ts
@@ -1,4 +1,4 @@
-import { ExecutionContext, Injectable } from '@nestjs/common';
+import { ArgumentsHost, ExecutionContext, Injectable } from '@nestjs/common';
 
 import { AbstractInterceptorService } from './abstract-interceptor.service';
 
@@ -13,7 +13,16 @@ export abstract class WebsocketInterceptorService extends AbstractInterceptorSer
    * @param context execution context from Nest
    * @returns the client object for the websocket adapter
    */
-  getClient(context: ExecutionContext) {
+  getClient(context: ArgumentsHost) {
     return context.switchToWs().getClient();
+  }
+
+  setRequestId(context: ArgumentsHost, requestId: any) {
+    const client = this.getClient(context);
+    client.requestId = requestId;
+  }
+
+  getRequestId(context: ArgumentsHost): any {
+    return this.getClient(context).requestId;
   }
 }

--- a/packages/nestjs-module/src/interceptor/providers/websocket-interceptor.service.ts
+++ b/packages/nestjs-module/src/interceptor/providers/websocket-interceptor.service.ts
@@ -1,11 +1,11 @@
-import { ArgumentsHost, ExecutionContext, Injectable } from '@nestjs/common';
+import { ArgumentsHost, Injectable } from '@nestjs/common';
 
 import { AbstractInterceptorService } from './abstract-interceptor.service';
 
 @Injectable()
 export abstract class WebsocketInterceptorService extends AbstractInterceptorService {
-  getCallPoint(context: ExecutionContext): string {
-    return this.reflector.get<string>('message', context.getHandler());
+  getCallPoint(context: ArgumentsHost): string {
+    return this.getClient(context).getPattern();
   }
 
   /**

--- a/packages/nestjs-module/src/ogma-core.module.ts
+++ b/packages/nestjs-module/src/ogma-core.module.ts
@@ -1,6 +1,5 @@
 import { Global, Module } from '@nestjs/common';
 
-import { OgmaFilterLogger } from './filter/ogma-filter.logger';
 import {
   DelegatorService,
   GqlInterceptorService,
@@ -26,6 +25,7 @@ import {
 } from './ogma.provider';
 import { OgmaService } from './ogma.service';
 import { ConfigurableModuleClass } from './ogma-core.module-definition';
+import { OgmaFilterService } from './ogma-filter.service';
 
 @Global()
 @Module({
@@ -72,7 +72,7 @@ import { ConfigurableModuleClass } from './ogma-core.module-definition';
     },
     OgmaService,
     DelegatorService,
-    OgmaFilterLogger,
+    OgmaFilterService,
   ],
   exports: [
     OGMA_INSTANCE,
@@ -83,7 +83,7 @@ import { ConfigurableModuleClass } from './ogma-core.module-definition';
     GqlInterceptorService,
     RpcInterceptorService,
     WebsocketInterceptorService,
-    OgmaFilterLogger,
+    OgmaFilterService,
   ],
 })
 export class OgmaCoreModule extends ConfigurableModuleClass {}

--- a/packages/nestjs-module/src/ogma-core.module.ts
+++ b/packages/nestjs-module/src/ogma-core.module.ts
@@ -1,5 +1,6 @@
 import { Global, Module } from '@nestjs/common';
 
+import { OgmaFilterLogger } from './filter/ogma-filter.logger';
 import {
   DelegatorService,
   GqlInterceptorService,
@@ -71,6 +72,7 @@ import { ConfigurableModuleClass } from './ogma-core.module-definition';
     },
     OgmaService,
     DelegatorService,
+    OgmaFilterLogger,
   ],
   exports: [
     OGMA_INSTANCE,
@@ -81,6 +83,7 @@ import { ConfigurableModuleClass } from './ogma-core.module-definition';
     GqlInterceptorService,
     RpcInterceptorService,
     WebsocketInterceptorService,
+    OgmaFilterLogger,
   ],
 })
 export class OgmaCoreModule extends ConfigurableModuleClass {}

--- a/packages/nestjs-module/src/ogma-filter.service.ts
+++ b/packages/nestjs-module/src/ogma-filter.service.ts
@@ -1,14 +1,14 @@
 import { ArgumentsHost, Injectable } from '@nestjs/common';
 import { OgmaOptions } from '@ogma/logger';
 
-import { InjectOgmaInterceptorOptions } from '../decorators';
-import { LogObject } from '../interceptor/interfaces/log.interface';
-import { DelegatorService } from '../interceptor/providers';
-import { OgmaInterceptorOptions } from '../interfaces';
-import { OgmaService } from '../ogma.service';
+import { InjectOgmaInterceptorOptions } from './decorators';
+import { LogObject } from './interceptor/interfaces/log.interface';
+import { DelegatorService } from './interceptor/providers';
+import { OgmaInterceptorOptions } from './interfaces';
+import { OgmaService } from './ogma.service';
 
 @Injectable()
-export class OgmaFilterLogger {
+export class OgmaFilterService {
   private json: boolean;
   private color: boolean;
 

--- a/packages/platform-express/src/express-interceptor.service.ts
+++ b/packages/platform-express/src/express-interceptor.service.ts
@@ -25,11 +25,6 @@ export class ExpressParser extends HttpInterceptorService {
     return `HTTP/${this.getHttpMajor(req)}.${this.getHttpMinor(req)}`;
   }
 
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const req = this.getRequest(context) as any;
-    req.requestId = requestId;
-  }
-
   private getHttpMajor(req: Request): number {
     return req.httpVersionMajor;
   }

--- a/packages/platform-fastify/src/fastify-interceptor.service.ts
+++ b/packages/platform-fastify/src/fastify-interceptor.service.ts
@@ -19,11 +19,6 @@ export class FastifyParser extends HttpInterceptorService {
     return req.raw.method || 'GET';
   }
 
-  setRequestId(context: ExecutionContext, requestId: string) {
-    const req = this.getRequest(context) as any;
-    req.requestId = requestId;
-  }
-
   getProtocol(context: ExecutionContext): string {
     const req = this.getRequest(context);
     return `HTTP/${req.raw.httpVersionMajor}.${req.raw.httpVersionMinor}`;

--- a/packages/platform-grpc/src/grpc-interceptor.service.ts
+++ b/packages/platform-grpc/src/grpc-interceptor.service.ts
@@ -19,9 +19,4 @@ export class GrpcParser extends RpcInterceptorService {
   getMethod() {
     return 'gRPC';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const grpcContext = this.getClient<{ requestId: string }>(context);
-    grpcContext.requestId = requestId;
-  }
 }

--- a/packages/platform-kafka/src/kafka-interceptor.service.ts
+++ b/packages/platform-kafka/src/kafka-interceptor.service.ts
@@ -20,9 +20,4 @@ export class KafkaParser extends RpcInterceptorService {
   getProtocol() {
     return 'kafka';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient<{ requestId: string }>(context);
-    client.requestId = requestId;
-  }
 }

--- a/packages/platform-mqtt/src/mqtt-interceptor.service.ts
+++ b/packages/platform-mqtt/src/mqtt-interceptor.service.ts
@@ -22,9 +22,4 @@ export class MqttParser extends RpcInterceptorService {
   getProtocol(): string {
     return 'mqtt';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient(context) as any;
-    client.requestId = requestId;
-  }
 }

--- a/packages/platform-nats/src/nats-interceptor.service.ts
+++ b/packages/platform-nats/src/nats-interceptor.service.ts
@@ -21,9 +21,4 @@ export class NatsParser extends RpcInterceptorService {
   getProtocol() {
     return 'nats';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient<NatsContext & { requestId: string }>(context);
-    client.requestId = requestId;
-  }
 }

--- a/packages/platform-rabbitmq/src/rabbitmq-interceptor.service.ts
+++ b/packages/platform-rabbitmq/src/rabbitmq-interceptor.service.ts
@@ -20,9 +20,4 @@ export class RabbitMqParser extends RpcInterceptorService {
   getProtocol() {
     return 'amqp';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient<RmqContext & { requestId: string }>(context);
-    client.requestId = requestId;
-  }
 }

--- a/packages/platform-redis/src/redis-interceptor.service.ts
+++ b/packages/platform-redis/src/redis-interceptor.service.ts
@@ -20,9 +20,4 @@ export class RedisParser extends RpcInterceptorService {
   getMethod(): string {
     return 'REDIS';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient<RedisContext & { requestId: string }>(context);
-    client.requestId = requestId;
-  }
 }

--- a/packages/platform-socket.io/src/socket-io-interceptor.service.ts
+++ b/packages/platform-socket.io/src/socket-io-interceptor.service.ts
@@ -20,9 +20,4 @@ export class SocketIOParser extends WebsocketInterceptorService {
   getMethod(): string {
     return 'socket.io';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient(context) as any;
-    client.requestId = requestId;
-  }
 }

--- a/packages/platform-tcp/src/tcp-interceptor.service.ts
+++ b/packages/platform-tcp/src/tcp-interceptor.service.ts
@@ -23,11 +23,6 @@ export class TcpParser extends RpcInterceptorService {
     return client.getSocketRef().socket.remoteFamily;
   }
 
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient<TcpContext & { requestId: string }>(context);
-    client.requestId = requestId;
-  }
-
   getClient<T = TcpContext>(context: ExecutionContext): T {
     return super.getClient(context);
   }

--- a/packages/platform-ws/src/ws-interceptor.service.ts
+++ b/packages/platform-ws/src/ws-interceptor.service.ts
@@ -14,9 +14,4 @@ export class WsParser extends WebsocketInterceptorService {
   getMethod(): string {
     return 'websocket';
   }
-
-  setRequestId(context: ExecutionContext, requestId: string): void {
-    const client = this.getClient(context) as any;
-    client.requestId = requestId;
-  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.0'
+lockfileVersion: '6.1'
 
 settings:
   autoInstallPeers: true


### PR DESCRIPTION
The new `OgmaFilterService` an be injected into a service and take in an exception and an arguments host object from Nest and print out metadata according to how the request failed. This will **only** happen, however, if the request has not been logged by an interceptor, meaning there will not be double logging of requests which would make logs noiser.

This is done by checking for the existence of the `requestId` added by the interceptor earlier in the call, and the major gain here is that now errors caused by guards or middleware can be caught can logged just as other requests are properly automatically logged as well, making Ogma now fully capable of logging **any** request type into Nest! This feature is opt-in, just as the interceptor is, but the power it brings is major due to now not leaving any requests unlogged.

The only downside at the moment is not being able to determing the time length of the request as most underlying transports don't grab the metadata of the start time, but there will be mentions of how users can implement such a feature to allow for that if they so choose.