### PR TITLE
docs(): update ogma logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![CI](https://github.com/jmcdo29/ogma/workflows/CI/badge.svg) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) [![Coffee](https://badgen.net/badge/Buy%20Me/A%20Coffee/purple?icon=kofi)](https://www.buymeacoffee.com/jmcdo29) [![Codacy Badge](https://app.codacy.com/project/badge/Grade/f03955cfcc16468d9d05ec8f5fc4924e)](https://www.codacy.com/gh/jmcdo29/ogma/dashboard?utm_source=github.com&utm_medium=referral&utm_content=jmcdo29/ogma&utm_campaign=Badge_Grade) [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/f03955cfcc16468d9d05ec8f5fc4924e)](https://www.codacy.com/gh/jmcdo29/ogma/dashboard?utm_source=github.com&utm_medium=referral&utm_content=jmcdo29/ogma&utm_campaign=Badge_Coverage)
 
   <p align="center">
-    <a href="https://jmcdo29.github.io/ogma" target="blank"><img src="apps/docs/static/img/logo.svg" width="120" alt="Ogma Logo" /></a>
+    <a href="https://jmcdo29.github.io/ogma" target="blank"><img src="https://ogma.jaymcdoniel.dev/logo.svg" width="220" alt="Ogma Logo" /></a>
   </p>
 
 </div>


### PR DESCRIPTION
The logo in the readme is not displayed (see screenshot):

<img width="891" alt="Schermata 2022-11-18 alle 21 20 18" src="https://user-images.githubusercontent.com/11542387/202845466-cc5dca5e-7239-432e-97f8-f1c238288eb1.png">
