### PR TITLE
docs: fix introduction links

### DIFF
--- a/apps/docs/src/pages/en/introduction.md
+++ b/apps/docs/src/pages/en/introduction.md
@@ -11,7 +11,7 @@ The first question you'll probably ask yourself is "Why is there another logger 
 
 ## Installation
 
-Installation is pretty simple, choose your favorite package manager and install [`@ogma/logger`](./logger). If you're working with [NestJS](https://docs.nestjs.com) you can install [`@ogma/nestjs-module`](./nestjs/module) instead and `@ogma/logger` will be installed for you.
+Installation is pretty simple, choose your favorite package manager and install [`@ogma/logger`](../logger). If you're working with [NestJS](https://docs.nestjs.com) you can install [`@ogma/nestjs-module`](../nestjs/module) instead and `@ogma/logger` will be installed for you.
 
 :::note
 


### PR DESCRIPTION
The links don't work properly on the docs site: https://ogma.jaymcdoniel.dev/en/introduction/

I think it's because of the trailing slash. Maybe it's easier to disable the trailing slash instead of "breaking" each link? Breaking meaning it's pointing to a wrong directory now when browsed on GitHub.

Edit: as I continue with the ogma setup, it looks like most of the links are broken. Let this PR be a reminder of this, instead of actual fix 😁