### PR TITLE
perf: performance improvements

### DIFF
--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -6,12 +6,14 @@ import { OgmaDefaults, OgmaOptions, PrintMessageOptions } from '../interfaces';
 import { OgmaPrintOptions } from '../interfaces/ogma-print-options';
 import { colorize, isNil } from '../utils';
 
+const checkIfHasSpaceRegex = /[^\n]$/;
+
 /**
  * The main logger instance
  */
 export class Ogma {
   private options: OgmaOptions;
-  private pid: number;
+  private pid: string;
   private hostname: string;
   private styler: Styler;
 
@@ -33,7 +35,7 @@ export class Ogma {
         .filter((key) => isNil(options[key]))
         .forEach((key) => delete options[key]);
     this.options = { ...OgmaDefaults, ...(options as OgmaOptions) };
-    this.pid = process.pid;
+    this.pid = process.pid.toString();
     this.hostname = hostname();
     if (options?.logLevel && LogLevel[options.logLevel] === undefined) {
       this.options.logLevel = OgmaDefaults.logLevel;
@@ -135,7 +137,7 @@ export class Ogma {
     }
 
     if (this.options.logPid) {
-      json.pid = this.pid;
+      json.pid = Number(this.pid);
     }
 
     json.correlationId = correlationId;
@@ -165,7 +167,7 @@ export class Ogma {
         2,
       )}`;
     }
-    return `${message}${/[^\n]$/.test(message) && addSpace ? ' ' : ''}`;
+    return `${message}${checkIfHasSpaceRegex.test(message) && addSpace ? ' ' : ''}`;
   }
 
   private formatStream(
@@ -198,7 +200,7 @@ export class Ogma {
       ? this.toStreamColor(application || this.options.application, Color.YELLOW) + ' '
       : '';
 
-    const pid = logPid ? this.wrapInBrackets(this.pid.toString()) + ' ' : '';
+    const pid = logPid ? this.wrapInBrackets(this.pid) + ' ' : '';
 
     return `${timestamp} ${formattedLevel} ${hostname}${applicationName}${pid}${correlationId} ${context} ${message}`;
   }

--- a/packages/logger/src/utils/colorize.ts
+++ b/packages/logger/src/utils/colorize.ts
@@ -1,6 +1,17 @@
 import { Color, OgmaSimpleType } from '@ogma/common';
 import { style as styler, Styler } from '@ogma/styler';
 
+const colorizeMap: Record<Color, string> = {
+  [Color.BLACK]: 'black',
+  [Color.RED]: 'red',
+  [Color.GREEN]: 'green',
+  [Color.YELLOW]: 'yellow',
+  [Color.BLUE]: 'blue',
+  [Color.MAGENTA]: 'magenta',
+  [Color.CYAN]: 'cyan',
+  [Color.WHITE]: 'white',
+};
+
 export function colorize(
   value: OgmaSimpleType,
   color: Color = Color.WHITE,
@@ -8,7 +19,8 @@ export function colorize(
   useColor = true,
 ): string {
   if (useColor) {
-    value = style[Color[color].toLowerCase()].apply(value);
+    return style[colorizeMap[color]].apply(value);
   }
+
   return value.toString();
 }

--- a/packages/styler/src/styler.ts
+++ b/packages/styler/src/styler.ts
@@ -2,151 +2,210 @@ import { OgmaStream } from '@ogma/common';
 
 import { Style } from './style.enum';
 
+const sgrColorMap = new Map([
+  ['3', true],
+  ['4', true],
+  ['9', true],
+]);
+
+const colorMap: Record<Style, string> = {
+  [Style.BLACK]: Style.BLACK.toString(),
+  [Style.BLACKBG]: Style.BLACKBG.toString(),
+  [Style.BRIGHTBLACK]: Style.BRIGHTBLACK.toString(),
+  [Style.BRIGHTBLACKBG]: Style.BRIGHTBLACKBG.toString(),
+  [Style.RED]: Style.RED.toString(),
+  [Style.REDBG]: Style.REDBG.toString(),
+  [Style.BRIGHTRED]: Style.BRIGHTRED.toString(),
+  [Style.BRIGHTREDBG]: Style.BRIGHTREDBG.toString(),
+  [Style.GREEN]: Style.GREEN.toString(),
+  [Style.GREENBG]: Style.GREENBG.toString(),
+  [Style.BRIGHTGREEN]: Style.BRIGHTGREEN.toString(),
+  [Style.BRIGHTGREENBG]: Style.BRIGHTGREENBG.toString(),
+  [Style.YELLOW]: Style.YELLOW.toString(),
+  [Style.YELLOWBG]: Style.YELLOWBG.toString(),
+  [Style.BRIGHTYELLOW]: Style.BRIGHTYELLOW.toString(),
+  [Style.BRIGHTYELLOWBG]: Style.BRIGHTYELLOWBG.toString(),
+  [Style.BLUE]: Style.BLUE.toString(),
+  [Style.BLUEBG]: Style.BLUEBG.toString(),
+  [Style.BRIGHTBLUE]: Style.BRIGHTBLUE.toString(),
+  [Style.MAGENTA]: Style.MAGENTA.toString(),
+  [Style.MAGENTABG]: Style.MAGENTABG.toString(),
+  [Style.BRIGHTMAGENTA]: Style.BRIGHTMAGENTA.toString(),
+  [Style.BRIGHTMAGENTABG]: Style.BRIGHTMAGENTABG.toString(),
+  [Style.CYAN]: Style.CYAN.toString(),
+  [Style.CYANBG]: Style.CYANBG.toString(),
+  [Style.BRIGHTCYAN]: Style.BRIGHTCYAN.toString(),
+  [Style.BIRGHTCYANBG]: Style.BIRGHTCYANBG.toString(),
+  [Style.WHITE]: Style.WHITE.toString(),
+  [Style.WHITEBG]: Style.WHITEBG.toString(),
+  [Style.BRIGHTWHIET]: Style.BRIGHTWHIET.toString(),
+  [Style.BRIGHTWHITEBG]: Style.BRIGHTWHITEBG.toString(),
+  [Style.BOLD]: Style.BOLD.toString(),
+  [Style.FAINT]: Style.FAINT.toString(),
+  [Style.ITALIC]: Style.ITALIC.toString(),
+  [Style.UNDERLINE]: Style.UNDERLINE.toString(),
+  [Style.BLINK]: Style.BLINK.toString(),
+  [Style.FASTBLINK]: Style.FASTBLINK.toString(),
+  [Style.INVERT]: Style.INVERT.toString(),
+  [Style.STRIKE]: Style.STRIKE.toString(),
+  [Style.DOUBLEUNDERLINE]: Style.DOUBLEUNDERLINE.toString(),
+  [Style.REVEAL]: Style.REVEAL.toString(),
+  [Style.FRAMED]: Style.FRAMED.toString(),
+  [Style.ENCIRCLED]: Style.ENCIRCLED.toString(),
+  [Style.OVERLINED]: Style.OVERLINED.toString(),
+  [Style.SUPER]: Style.SUPER.toString(),
+  [Style.SUB]: Style.SUB.toString(),
+  [Style.NONE]: Style.NONE.toString(),
+  [Style.CONCEAL]: Style.CONCEAL.toString(),
+  [Style.COLOR]: Style.COLOR.toString(),
+  [Style.BGCOLOR]: Style.BGCOLOR.toString(),
+  [Style.BRIGHTBLUEBG]: Style.BRIGHTBLUEBG.toString(),
+};
+
 export class Styler {
-  private stylesToApply = [];
+  private stylesToApply = '';
   private colorDepth = 16;
   private useStyle = true;
   public get black() {
-    return this.sgr(Style.BLACK);
+    return this.sgr(colorMap[Style.BLACK]);
   }
   public get blackBg() {
-    return this.sgr(Style.BLACKBG);
+    return this.sgr(colorMap[Style.BLACKBG]);
   }
   public get bBlack() {
-    return this.sgr(Style.BRIGHTBLACK);
+    return this.sgr(colorMap[Style.BRIGHTBLACK]);
   }
   public get bBlackBg() {
-    return this.sgr(Style.BRIGHTBLACKBG);
+    return this.sgr(colorMap[Style.BRIGHTBLACKBG]);
   }
   public get red() {
-    return this.sgr(Style.RED);
+    return this.sgr(colorMap[Style.RED]);
   }
   public get redBg() {
-    return this.sgr(Style.REDBG);
+    return this.sgr(colorMap[Style.REDBG]);
   }
   public get bRed() {
-    return this.sgr(Style.BRIGHTRED);
+    return this.sgr(colorMap[Style.BRIGHTRED]);
   }
   public get bRedBg() {
-    return this.sgr(Style.BRIGHTREDBG);
+    return this.sgr(colorMap[Style.BRIGHTREDBG]);
   }
   public get green() {
-    return this.sgr(Style.GREEN);
+    return this.sgr(colorMap[Style.GREEN]);
   }
   public get greenBg() {
-    return this.sgr(Style.GREENBG);
+    return this.sgr(colorMap[Style.GREENBG]);
   }
   public get bGreen() {
-    return this.sgr(Style.BRIGHTGREEN);
+    return this.sgr(colorMap[Style.BRIGHTGREEN]);
   }
   public get bGreenBg() {
-    return this.sgr(Style.BRIGHTGREENBG);
+    return this.sgr(colorMap[Style.BRIGHTGREENBG]);
   }
   public get yellow() {
-    return this.sgr(Style.YELLOW);
+    return this.sgr(colorMap[Style.YELLOW]);
   }
   public get yellowBg() {
-    return this.sgr(Style.YELLOWBG);
+    return this.sgr(colorMap[Style.YELLOWBG]);
   }
   public get bYellow() {
-    return this.sgr(Style.BRIGHTYELLOW);
+    return this.sgr(colorMap[Style.BRIGHTYELLOW]);
   }
-
   public get bYellowBg() {
-    return this.sgr(Style.BRIGHTYELLOWBG);
+    return this.sgr(colorMap[Style.BRIGHTYELLOWBG]);
   }
   public get blue() {
-    return this.sgr(Style.BLUE);
+    return this.sgr(colorMap[Style.BLUE]);
   }
   public get blueBg() {
-    return this.sgr(Style.BLUEBG);
+    return this.sgr(colorMap[Style.BLUEBG]);
   }
   public get bBlue() {
-    return this.sgr(Style.BRIGHTBLUE);
+    return this.sgr(colorMap[Style.BRIGHTBLUE]);
   }
   public get bBlueBg() {
-    return this.sgr(Style.BRIGHTBLUEBG);
+    return this.sgr(colorMap[Style.BRIGHTBLUEBG]);
   }
   public get magenta() {
-    return this.sgr(Style.MAGENTA);
+    return this.sgr(colorMap[Style.MAGENTA]);
   }
   public get magentaBg() {
-    return this.sgr(Style.MAGENTABG);
+    return this.sgr(colorMap[Style.MAGENTABG]);
   }
   public get bMagenta() {
-    return this.sgr(Style.BRIGHTMAGENTA);
+    return this.sgr(colorMap[Style.BRIGHTMAGENTA]);
   }
   public get bMagentaBg() {
-    return this.sgr(Style.BRIGHTMAGENTABG);
+    return this.sgr(colorMap[Style.BRIGHTMAGENTABG]);
   }
   public get cyan() {
-    return this.sgr(Style.CYAN);
+    return this.sgr(colorMap[Style.CYAN]);
   }
   public get cyanBg() {
-    return this.sgr(Style.CYANBG);
+    return this.sgr(colorMap[Style.CYANBG]);
   }
   public get bCyan() {
-    return this.sgr(Style.BRIGHTCYAN);
+    return this.sgr(colorMap[Style.BRIGHTCYAN]);
   }
   public get bCyanBg() {
-    return this.sgr(Style.BIRGHTCYANBG);
+    return this.sgr(colorMap[Style.BIRGHTCYANBG]);
   }
   public get white() {
-    return this.sgr(Style.WHITE);
+    return this.sgr(colorMap[Style.WHITE]);
   }
   public get whiteBg() {
-    return this.sgr(Style.WHITEBG);
+    return this.sgr(colorMap[Style.WHITEBG]);
   }
   public get bWhite() {
-    return this.sgr(Style.BRIGHTWHIET);
+    return this.sgr(colorMap[Style.BRIGHTWHIET]);
   }
   public get bWhiteBg() {
-    return this.sgr(Style.BRIGHTWHITEBG);
+    return this.sgr(colorMap[Style.BRIGHTWHITEBG]);
   }
   public get bold() {
-    return this.sgr(Style.BOLD);
+    return this.sgr(colorMap[Style.BOLD]);
   }
   public get faint() {
-    return this.sgr(Style.FAINT);
+    return this.sgr(colorMap[Style.FAINT]);
   }
   public get italic() {
-    return this.sgr(Style.ITALIC);
+    return this.sgr(colorMap[Style.ITALIC]);
   }
   public get underline() {
-    return this.sgr(Style.UNDERLINE);
+    return this.sgr(colorMap[Style.UNDERLINE]);
   }
   public get blink() {
-    return this.sgr(Style.BLINK);
+    return this.sgr(colorMap[Style.BLINK]);
   }
   public get fastBlink() {
-    return this.sgr(Style.FASTBLINK);
+    return this.sgr(colorMap[Style.FASTBLINK]);
   }
   public get invert() {
-    return this.sgr(Style.INVERT);
+    return this.sgr(colorMap[Style.INVERT]);
   }
   public get strikeThrough() {
-    return this.sgr(Style.STRIKE);
+    return this.sgr(colorMap[Style.STRIKE]);
   }
   public get doubleUnderline() {
-    return this.sgr(Style.DOUBLEUNDERLINE);
+    return this.sgr(colorMap[Style.DOUBLEUNDERLINE]);
   }
   public get reveal() {
-    return this.sgr(Style.REVEAL);
+    return this.sgr(colorMap[Style.REVEAL]);
   }
   public get framed() {
-    return this.sgr(Style.FRAMED);
+    return this.sgr(colorMap[Style.FRAMED]);
   }
   public get encircled() {
-    return this.sgr(Style.ENCIRCLED);
+    return this.sgr(colorMap[Style.ENCIRCLED]);
   }
   public get overlined() {
-    return this.sgr(Style.OVERLINED);
+    return this.sgr(colorMap[Style.OVERLINED]);
   }
   public get superscript() {
-    return this.sgr(Style.SUPER);
+    return this.sgr(colorMap[Style.SUPER]);
   }
   public get subscript() {
-    return this.sgr(Style.SUB);
+    return this.sgr(colorMap[Style.SUB]);
   }
 
   public constructor(stream: Pick<OgmaStream, 'getColorDepth'> = process.stdout) {
@@ -172,12 +231,13 @@ export class Styler {
    * @returns A string that has the proper SGR values
    */
   public apply(val: string | number | boolean) {
-    let retString = `${this.stylesToApply.join('')}${val}`;
-    if (this.stylesToApply.length) {
-      retString += '\x1B[0m';
-    }
-    this.stylesToApply = [];
-    return retString;
+    if (this.stylesToApply === '') return val.toString();
+
+    const returnValue = `${this.stylesToApply}${val}\x1B[0m`;
+
+    this.stylesToApply = '';
+
+    return returnValue;
   }
 
   /**
@@ -224,18 +284,18 @@ export class Styler {
   /**
    * @link https://en.wikipedia.org/wiki/ANSI_escape_code#SGR
    */
-  private sgr(val: number | string): this {
+  private sgr(val: string): this {
     if (
-      (this.colorDepth === 1 &&
-        val.toString().length >= 2 &&
-        ['3', '4', '9'].includes(val.toString()[0])) ||
-      val.toString().substr(0, 2) === '10'
+      (this.colorDepth === 1 && val.length >= 2 && sgrColorMap.has(val[0])) ||
+      (val[0] === '1' && val[1] === '0')
     ) {
       return this;
     }
+
     if (this.useStyle) {
-      this.stylesToApply.push(`\x1B[${val.toString()}m`);
+      this.stylesToApply += `\x1B[${val}m`;
     }
+
     return this;
   }
 }


### PR DESCRIPTION
Hello!

I did some benchmarks on your library and here what I found, the initial profiler was:

```
Statistical profiling result from ogma-initial-solution.log, (11121 ticks, 1 unaccounted, 0 excluded).

 [Shared libraries]:
   ticks  total  nonlib   name
   2619   23.6%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    525    4.7%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
     54    0.5%          [vdso]
      1    0.0%          /usr/lib/x86_64-linux-gnu/libstdc++.so.6.0.28

 [JavaScript]:
   ticks  total  nonlib   name
    130    1.2%    1.6%  LazyCompile: *formatStream /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/logger/src/logger/ogma.js:151:17
     70    0.6%    0.9%  LazyCompile: *<anonymous> /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/dist/ogma-log.stress.js:1:1
     59    0.5%    0.7%  LazyCompile: *_write node:internal/streams/writable:283:16
     47    0.4%    0.6%  LazyCompile: *get magenta /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/styler/lib/styler.js:83:16
     41    0.4%    0.5%  LazyCompile: *get cyan /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/styler/lib/styler.js:95:13
     41    0.4%    0.5%  LazyCompile: *apply /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/styler/lib/styler.js:164:10
     35    0.3%    0.4%  LazyCompile: *writeGeneric node:internal/stream_base_commons:147:22
     27    0.2%    0.3%  RegExp: [^\n]$
      3    0.0%    0.0%  LazyCompile: *afterWrite node:internal/streams/writable:487:20
      1    0.0%    0.0%  Function: ^onwrite node:internal/streams/writable:425:17
      1    0.0%    0.0%  Function: ^normalizeString node:path:66:25
      1    0.0%    0.0%  Function: ^formatStream /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/logger/src/logger/ogma.js:151:17
      1    0.0%    0.0%  Function: ^Socket._writeGeneric node:net:791:42
```

> [Source](https://github.com/jmcdo29/ogma/files/10368728/ogma-initial-solution.txt)

With the optimizations, it became:

```
Statistical profiling result from ogma-final-solution.log, (8995 ticks, 8 unaccounted, 0 excluded).

 [Shared libraries]:
   ticks  total  nonlib   name
   1792   19.9%          /home/h4ad/.asdf/installs/nodejs/16.16.0/bin/node
    604    6.7%          /usr/lib/x86_64-linux-gnu/libc-2.31.so
     53    0.6%          [vdso]

 [JavaScript]:
   ticks  total  nonlib   name
    124    1.4%    1.9%  LazyCompile: *formatStream /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/logger/src/logger/ogma.js:152:17
     49    0.5%    0.7%  LazyCompile: *_write node:internal/streams/writable:283:16
     48    0.5%    0.7%  LazyCompile: *get magenta /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/styler/lib/styler.js:123:16
     42    0.5%    0.6%  LazyCompile: *<anonymous> /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/dist/ogma-log.stress.js:1:1
     41    0.5%    0.6%  LazyCompile: *writeGeneric node:internal/stream_base_commons:147:22
     38    0.4%    0.6%  LazyCompile: *get cyan /home/h4ad/Projects/opensource/performance-analysis/ogma-performance-analysis/node_modules/@ogma/styler/lib/styler.js:135:13
     24    0.3%    0.4%  RegExp: [^\n]$
      3    0.0%    0.0%  LazyCompile: *afterWrite node:internal/streams/writable:487:20
      1    0.0%    0.0%  Function: ^Socket._writeGeneric node:net:791:42
      1    0.0%    0.0%  Function: ^Socket._write node:net:828:35
```

> [Source](https://github.com/jmcdo29/ogma/files/10368737/ogma-final-solution.txt)

It didn't change too much, only the number of ticks and some functions.

When we compare the benchmarks, now we see some improvements, before:

```
'NestJS Logger x 7,214 ops/sec ±1.36% (86 runs sampled)',
'Ogma x 85,376 ops/sec ±4.57% (72 runs sampled)',
'Pino x 776,318 ops/sec ±4.46% (77 runs sampled)',
'console.log x 110,891 ops/sec ±2.17% (78 runs sampled)',
'process.stdout x 274,788 ops/sec ±3.16% (77 runs sampled)'
```

After:

```
'NestJS Logger x 7,300 ops/sec ±1.46% (82 runs sampled)',
'Ogma x 102,430 ops/sec ±3.98% (66 runs sampled)',
'Pino x 738,057 ops/sec ±6.79% (76 runs sampled)',
'console.log x 114,343 ops/sec ±2.44% (78 runs sampled)',
'process.stdout x 258,215 ops/sec ±2.32% (65 runs sampled)'
```

> [Benchmarks](https://gist.github.com/H4ad/38fc55fae31b4f0b77660094bdb17fbe)

Almost 20% of improvement, getting very close to `console.log`.

## Improvements that could introduce breaking change

All the improvements I made, I tried to not modify your API, so I only improve the existing code.

If you want to introduce breaking changes, in the future, you can refactor `styler.ts` to use methods instead `getters`, see the difference in performance:

```
'Getter x 67,877,439 ops/sec ±1.48% (89 runs sampled)',
'Method x 1,078,455,416 ops/sec ±0.48% (89 runs sampled)'
```

> This is a pure performance and is not a benchmark of your library.

Also, these lines:

https://github.com/jmcdo29/ogma/blob/a76f0805d755771e666540a7a2bf0f16ca8e676b/packages/logger/src/logger/ogma.ts#L123-L130

I don't know if you are familiar with the concept of [Hidden Classes](https://blog.bitsrc.io/secret-behind-javascript-performance-v8-hidden-classes-ba4d0ebfb89d) in V8, but in general, using `delete` operator is very heavy and is not recommended.

Also, you could initialize all properties of `json` object with `undefined` to indicate to V8 to reutilize the same Hidden Class across every option in the log, in the way that is now, the initial Hidden Class created for `json` will be mutated every time you add a new property.

Finally, your library will reach a maximum of performance using `process.stdout` eventually, so I recommend you to read the source code of `pino` to see what they are doing because their library is even faster than writing directly to the `stdout`.

