### PR TITLE
feat(logger): allow for each to be set at a global level

### DIFF
--- a/.changeset/six-pigs-smash.md
+++ b/.changeset/six-pigs-smash.md
@@ -1,0 +1,5 @@
+---
+'@ogma/logger': minor
+---
+
+Allow for `each` to be set at a global level when initializing an Ogma instance

--- a/apps/docs/src/pages/en/logger.md
+++ b/apps/docs/src/pages/en/logger.md
@@ -69,6 +69,14 @@ This option is available in `@ogma/logger@^2.4.0`
 
 :::
 
+This option is also available globally, so you can set it on the instantiation of your ogma instance and no worry about it on each call.
+
+::: info
+
+This option is available in `@ogma/logger@^2.5.0`
+
+:::
+
 ## Ogma Options
 
 | name | type | use |
@@ -84,6 +92,7 @@ This option is available in `@ogma/logger@^2.4.0`
 | logPid | boolean | An optional property you can set if you don't want to log the PID. |
 | logApplication | boolean | An optional property you can set if you don't want to the the applicaiton name. |
 | logHostnam | boolean | An optional property you can set if you don't want to log the hostname ofthe machine you're on. |
+| each | boolean | An optional property that determines if array values should be printed on separate lines by default or not |
 
 :::note
 

--- a/packages/logger/src/interfaces/ogma-options.ts
+++ b/packages/logger/src/interfaces/ogma-options.ts
@@ -102,6 +102,11 @@ export interface OgmaOptions {
    * Use with caution as determining if properties should be restricted may take away from _some_ performance
    */
   masks?: string[];
+  /**
+   * Log each member of an array out on a new line. This is a global option tthat can be overridden per call as
+   * desired.
+   */
+  each: boolean;
   [index: string]: any;
 }
 
@@ -126,4 +131,5 @@ export const OgmaDefaults: OgmaOptions = {
   logPid: true,
   logApplication: true,
   logHostname: true,
+  each: false,
 };

--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -16,6 +16,7 @@ export class Ogma {
   private pid: string;
   private hostname: string;
   private styler: Styler;
+  private each: boolean;
 
   /**
    * An alias for `ogma.verbose`. `FINE` is what is printed as the log level
@@ -47,6 +48,7 @@ export class Ogma {
       this.setStreamColorDepth();
     }
     this.styler = style.child(this.options.stream as Pick<OgmaStream, 'getColorDepth'>);
+    this.each = this.options.each;
   }
 
   private setStreamColorDepth(): void {
@@ -177,7 +179,7 @@ export class Ogma {
       correlationId = '',
       formattedLevel,
       context = '',
-      each = false,
+      each = this.each,
     }: PrintMessageOptions,
   ): string {
     if (Array.isArray(message) && each) {

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -296,6 +296,19 @@ OgmaSuite(
   },
 );
 OgmaSuite(
+  'it should print each array value if the global option "each" is true',
+  ({ writeSpy, ogmaFactory, getFirstCallString }) => {
+    const ogma = ogmaFactory({ each: true });
+    const messages = ['hello', 42, { key: 'value' }, true];
+    ogma.log(messages);
+    is(writeSpy.calls.size, 1, 'Expected there to be one calls to the write stream');
+    const expected = `hello 42 {
+  "key": "value"
+} true`;
+    match(getFirstCallString(writeSpy), expected);
+  },
+);
+OgmaSuite(
   'it should respect array values that have newline characters',
   ({ writeSpy, ogmaFactory, getFirstCallString }) => {
     const ogma = ogmaFactory();


### PR DESCRIPTION
@tukusejssirs this should be the PR you're looking for to add support for `each` being set globally. Give it a once over if ya would, please?