### PR TITLE
fix: properly use on-exit-lek-free for worker threads and "each" printing

### DIFF
--- a/.changeset/fluffy-steaks-breathe.md
+++ b/.changeset/fluffy-steaks-breathe.md
@@ -1,0 +1,5 @@
+---
+'@ogma/logger': patch
+---
+
+Make it so that the "each" option does not end up double printing the arrays of objects passed to the logger

--- a/.changeset/nice-socks-develop.md
+++ b/.changeset/nice-socks-develop.md
@@ -1,0 +1,5 @@
+---
+'@ogma/logger': patch
+---
+
+Fix an issue with sonic-boom not printing all the logs in a worker thread

--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -302,6 +302,7 @@ export class Ogma {
   ): string {
     if (Array.isArray(message) && each) {
       const messages = message;
+      message = '';
       for (let i = 0; i < messages.length; i++) {
         message += this.stringifyObject(messages[i], i === 0, i + 1 < messages.length);
       }

--- a/packages/logger/src/utils/sonic-boom.ts
+++ b/packages/logger/src/utils/sonic-boom.ts
@@ -1,5 +1,7 @@
 import { OgmaStream } from '@ogma/common';
+import * as onExit from 'on-exit-leak-free';
 import SonicBoom from 'sonic-boom';
+import { isMainThread } from 'worker_threads';
 
 const noop = (_args?: any) => true; // eslint-disable-line @typescript-eslint/no-empty-function
 
@@ -7,11 +9,17 @@ const noop = (_args?: any) => true; // eslint-disable-line @typescript-eslint/no
  * thanks pinojs
  * ref: https://github.com/pinojs/pino/blob/27d2ab8b58e64547fd24864c2f21ac898f4752c4/lib/tools.js#L219
  */
-function buildSafeSonicBoom(opts: { fd: typeof process['stdout']['fd'] }) {
-  // the ?? 1 is here to handle worker threads like using vitest
-  const stream = new SonicBoom({ fd: opts.fd ?? 1 });
-
+function buildSafeSonicBoom(opts) {
+  const stream = new SonicBoom(opts);
   stream.on('error', filterBrokenPipe);
+  // if we are sync: false, we must flush on exit
+  if (!opts.sync && isMainThread) {
+    onExit.register(stream, autoEnd);
+
+    stream.on('close', function () {
+      onExit.unregister(stream);
+    });
+  }
   return stream;
 
   function filterBrokenPipe(err) {
@@ -29,6 +37,27 @@ function buildSafeSonicBoom(opts: { fd: typeof process['stdout']['fd'] }) {
     }
     stream.removeListener('error', filterBrokenPipe);
     stream.emit('error', err);
+  }
+}
+
+function autoEnd(stream, eventName) {
+  // This check is needed only on some platforms
+  /* istanbul ignore next */
+  if (stream.destroyed) {
+    return;
+  }
+
+  if (eventName === 'beforeExit') {
+    // We still have an event loop, let's use it
+    stream.flush();
+    stream.on('drain', function () {
+      stream.end();
+    });
+  } else {
+    // For some reason istanbul is not detecting this, but it's there
+    /* istanbul ignore next */
+    // We do not have an event loop, so flush synchronously
+    stream.flushSync();
   }
 }
 

--- a/packages/logger/src/utils/sonic-boom.ts
+++ b/packages/logger/src/utils/sonic-boom.ts
@@ -3,7 +3,7 @@ import * as onExit from 'on-exit-leak-free';
 import SonicBoom from 'sonic-boom';
 import { isMainThread } from 'worker_threads';
 
-const noop = (_args?: any) => true; // eslint-disable-line @typescript-eslint/no-empty-function
+const noop = (_args?: any) => true;
 
 /**
  * thanks pinojs

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -289,10 +289,14 @@ OgmaSuite(
     const messages = ['hello', 42, { key: 'value' }, true];
     ogma.log(messages, { each: true });
     is(writeSpy.calls.size, 1, 'Expected there to be one calls to the write stream');
-    const expected = `hello 42 {
+    const expected = ` hello 42 {
   "key": "value"
 } true`;
-    match(getFirstCallString(writeSpy), expected);
+    match(
+      getFirstCallString(writeSpy),
+      expected,
+      `Expected "${getFirstCallString(writeSpy)}" to match the value "${expected}"`,
+    );
   },
 );
 OgmaSuite(


### PR DESCRIPTION
Due to the use of `sonic-boom` there were some issues in worker threads not properly flushing the log stream by the time the thread closed, meaning the logs were lost. That should now be resolved.

Along with that, the `each` option of the logger was double-printing the data because of a  mistake around not overriding the `message` variable