### PR TITLE
fix: allow for the value of a masked property to be undefined or null

### DIFF
--- a/.changeset/lovely-icons-help.md
+++ b/.changeset/lovely-icons-help.md
@@ -1,0 +1,5 @@
+---
+'@ogma/logger': patch
+---
+
+Allow for the value of a masked property to be null or undefined

--- a/packages/logger/src/logger/ogma.ts
+++ b/packages/logger/src/logger/ogma.ts
@@ -154,7 +154,7 @@ export class Ogma {
     const seen = new WeakSet();
     return (key: string, value: any): string | number | boolean => {
       if (this.cachedMasks?.has(key)) {
-        return '*'.repeat(value.toString().length);
+        return '*'.repeat(value?.toString().length ?? 9);
       }
 
       if (value === null) return value;
@@ -326,10 +326,16 @@ export class Ogma {
       return '';
     }
 
-    if (this.cachedContextFormatted.has(value) && this.cachedContextFormatted.get(value).has(color))
+    if (
+      this.cachedContextFormatted.has(value) &&
+      this.cachedContextFormatted.get(value).has(color)
+    ) {
       return this.cachedContextFormatted.get(value).get(color);
+    }
 
-    if (!this.cachedContextFormatted.has(value)) this.cachedContextFormatted.set(value, new Map());
+    if (!this.cachedContextFormatted.has(value)) {
+      this.cachedContextFormatted.set(value, new Map());
+    }
 
     const cachedValue = colorize(
       this.wrapInBrackets(value),

--- a/packages/logger/test/ogma.spec.ts
+++ b/packages/logger/test/ogma.spec.ts
@@ -272,10 +272,30 @@ OgmaSuite(
 );
 for (const json of [true, false]) {
   OgmaSuite(
-    `it should make the value for the password. JSON: ${json}`,
+    `it should mask the value for the password. JSON: ${json}`,
     ({ writeSpy, ogmaFactory, getFirstCallString }) => {
       const ogma = ogmaFactory({ json, masks: ['password'] });
       ogma.log({ username: 'something', password: 'mask this' });
+      const loggedVal = getFirstCallString(writeSpy);
+      match(loggedVal, /"username":\s?"something",/);
+      match(loggedVal, /"password":\s?"\*{9}"/);
+    },
+  );
+  OgmaSuite(
+    `it should allow for an undefined value for the masked field. JSON: ${json}`,
+    ({ writeSpy, ogmaFactory, getFirstCallString }) => {
+      const ogma = ogmaFactory({ json, masks: ['password'] });
+      ogma.log({ username: 'something', password: undefined });
+      const loggedVal = getFirstCallString(writeSpy);
+      match(loggedVal, /"username":\s?"something",/);
+      match(loggedVal, /"password":\s?"\*{9}"/);
+    },
+  );
+  OgmaSuite(
+    `it should allow for an null value for the masked field. JSON: ${json}`,
+    ({ writeSpy, ogmaFactory, getFirstCallString }) => {
+      const ogma = ogmaFactory({ json, masks: ['password'] });
+      ogma.log({ username: 'something', password: null });
       const loggedVal = getFirstCallString(writeSpy);
       match(loggedVal, /"username":\s?"something",/);
       match(loggedVal, /"password":\s?"\*{9}"/);


### PR DESCRIPTION
Now when using the `masks` option, if an object comes in with an `undefined` or `null` value, instead of throwing an error or a message about being too complex to serialize, Ogma will properly handle the value and replace it with nine (9) asterisks as a default. This will probably eventually be made configurable if the desire is there. Alternatively, we may end up just skipping the masking instead. Will wait for feedback

ref: #1678