### PR TITLE
chore: run pnpm install after version bumps for the sake of ci

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -414,7 +414,7 @@ importers:
         specifier: ^9.0.0 || ^10.0.0
         version: 10.0.4(@nestjs/common@10.0.4)(@nestjs/microservices@10.0.4)(@nestjs/platform-express@10.0.4)(@nestjs/websockets@10.0.4)(reflect-metadata@0.1.13)(rxjs@7.8.1)
       '@ogma/logger':
-        specifier: workspace:^3.1.2
+        specifier: workspace:^3.1.6
         version: link:../logger
       '@ogma/styler':
         specifier: workspace:^1.0.0


### PR DESCRIPTION
This makes CI immediately work again, due to how pnpm strictness with the lockfile and workspace version works