### PR TITLE
feat: allow for composing styles thruogh child stylers

### DIFF
--- a/.changeset/hot-stingrays-laugh.md
+++ b/.changeset/hot-stingrays-laugh.md
@@ -1,0 +1,5 @@
+---
+'@ogma/styler': minor
+---
+
+Allow for child stylers to compose styles on sub-strings

--- a/apps/docs/src/pages/en/styler.md
+++ b/apps/docs/src/pages/en/styler.md
@@ -37,6 +37,19 @@ console.log(style.blue.yellowBg.underline.apply('Hello World!'));
 
 ![blue-yellow-bg-underline](https://ogma-docs-images.s3-us-west-2.amazonaws.com/blue-yellowbg-underline.png)
 
+## Composing Styles
+
+If you want to take advantage of applying style to a subset of the string you are currently styling, you can invoke a child styler and apply the sub-style to only a portion of the sub-string:
+
+```ts
+console.log(
+  `${style.blue.apply(
+    `Hello ${style.child().underline.apply('blue')} world`
+  )}`
+);
+// prints \x1B[34mHello \x1B[4mblue\x1B[0m\x1B[34m world\x1B[0m
+```
+
 ## What styles are available?
 
 Most of the [values on the SGR list](<https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters>) are available to use. `underline`, `italic`, `bold,` `double-underline`, `blink`, and `color` to name a few.

--- a/packages/styler/src/styler.ts
+++ b/packages/styler/src/styler.ts
@@ -231,8 +231,12 @@ export class Styler {
    * @returns A string that has the proper SGR values
    */
   public apply(val: string | number | boolean) {
-    if (this.stylesToApply === '') return val.toString();
-
+    if (this.stylesToApply === '') {
+      return val.toString();
+    }
+    if (typeof val === 'string' && /\x1B\[0m/.test(val)) {
+      val = val.replace(/\x1B\[0m/g, `\x1B[0m${this.stylesToApply}`);
+    }
     const returnValue = `${this.stylesToApply}${val}\x1B[0m`;
 
     this.stylesToApply = '';

--- a/packages/styler/test/styles.spec.ts
+++ b/packages/styler/test/styles.spec.ts
@@ -92,5 +92,20 @@ StylerSuite('it should apply absolutely no styles', () => {
   const nsStyle = style.child();
   is(nsStyle.blue.underline.blink.apply(hello), hello);
   process.env.NO_STYLE = ogNO_STYLE;
+  if (process.env.NO_STYLE === 'undefined') {
+    process.env.NO_STYLE = '';
+  }
+});
+StylerSuite('Composition, usage inside a styler should still apply outer style', () => {
+  const output = style.blue.apply(`hello ${style.child().underline.apply('blue')} world`);
+  const expectedString = '\x1B[34mhello \x1B[4mblue\x1B[0m\x1B[34m world\x1B[0m';
+  is(
+    output,
+    expectedString,
+    `Expected ${expectedString.replaceAll(/\x1B/g, '\\x1B')}, but received ${output.replaceAll(
+      /\x1B/g,
+      '\\x1B',
+    )}`,
+  );
 });
 StylerSuite.run();


### PR DESCRIPTION
If you want to take advantage of applying style to a subset of the string you are currently styling, you can invoke a child styler and apply the sub-style to only a portion of the sub-string:

```ts
console.log(
  `${style.blue.apply(
    `Hello ${style.child().underline.apply('blue')} world`
  )}`
);
// prints \x1B[34mHello \x1B[4mblue\x1B[0m\x1B[34m world\x1B[0m
```