### PR TITLE
fix: explicitly set the styler type

### DIFF
--- a/.changeset/violet-steaks-applaud.md
+++ b/.changeset/violet-steaks-applaud.md
@@ -1,0 +1,5 @@
+---
+'@ogma/nestjs-module': patch
+---
+
+Explicitly set the styler type

--- a/packages/nestjs-module/src/ogma.service.ts
+++ b/packages/nestjs-module/src/ogma.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, LoggerService, Optional } from '@nestjs/common';
 import { LogLevel, OgmaWritableLevel } from '@ogma/common';
 import { Ogma } from '@ogma/logger';
+import type { Styler } from '@ogma/styler';
 
 import { InjectOgma, InjectOgmaContext, InjectTraceMethod } from './decorators';
 import { OgmaServiceMeta } from './interfaces';
@@ -47,7 +48,7 @@ export class OgmaService implements LoggerService {
    * instance that the logger uses for custom coloring without needing
    * to manage a new styler instance
    */
-  public get style() {
+  public get style(): Styler {
     return this.ogma.style;
   }
 


### PR DESCRIPTION
This fixes an issue where the build procecss auto adds and `import` statement
that fails in other environments when the package gets installed.